### PR TITLE
Arts 285

### DIFF
--- a/trial-config-service/src/main/java/uk/ac/ox/ndph/mts/trial_config_service/config/GitRepo.java
+++ b/trial-config-service/src/main/java/uk/ac/ox/ndph/mts/trial_config_service/config/GitRepo.java
@@ -17,6 +17,7 @@ import uk.ac.ox.ndph.mts.trial_config_service.exception.InvalidConfigException;
 
 import javax.annotation.PostConstruct;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -82,10 +83,9 @@ public class GitRepo {
         return fileBytes;
     }
 
-    private Path getRepoPath() {
-        Path source = Paths.get("resources");
+    private Path getRepoPath() throws FileNotFoundException {
+        Path source = Paths.get("gitRepo");
         Path newFolder = Paths.get(source + File.separator + "jsonConfig" + File.separator);
-
         return newFolder;
     }
 

--- a/trial-config-service/src/main/java/uk/ac/ox/ndph/mts/trial_config_service/config/GitRepo.java
+++ b/trial-config-service/src/main/java/uk/ac/ox/ndph/mts/trial_config_service/config/GitRepo.java
@@ -18,6 +18,7 @@ import uk.ac.ox.ndph.mts.trial_config_service.exception.InvalidConfigException;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -84,8 +85,8 @@ public class GitRepo {
     }
 
     private Path getRepoPath() {
-        Path source = Paths.get(this.getClass().getResource("/").getPath());
-        Path newFolder = Paths.get(source.toAbsolutePath() + "/config/");
+        Path source = Paths.get("resources");
+        Path newFolder = Paths.get(source + File.separator + "configx" + File.separator);
 
         return newFolder;
     }

--- a/trial-config-service/src/main/java/uk/ac/ox/ndph/mts/trial_config_service/config/GitRepo.java
+++ b/trial-config-service/src/main/java/uk/ac/ox/ndph/mts/trial_config_service/config/GitRepo.java
@@ -3,7 +3,6 @@ package uk.ac.ox.ndph.mts.trial_config_service.config;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.api.errors.InvalidConfigurationException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
@@ -17,7 +16,6 @@ import org.springframework.stereotype.Component;
 import uk.ac.ox.ndph.mts.trial_config_service.exception.InvalidConfigException;
 
 import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -28,7 +26,7 @@ import java.nio.file.Paths;
 public class GitRepo {
 
     @PostConstruct
-    public void init() throws InvalidConfigurationException {
+    public void init() throws InvalidConfigException {
         try {
             Files.createDirectories(getRepoPath());
 
@@ -37,9 +35,9 @@ public class GitRepo {
                 .setDirectory(getRepoPath().toFile())
                 .call();
         } catch (GitAPIException gitEx) {
-            throw new InvalidConfigurationException(gitEx.getMessage());
+            throw new InvalidConfigException(gitEx.getMessage());
         } catch (IOException ioEx) {
-            throw new InvalidConfigurationException(ioEx.getMessage());
+            throw new InvalidConfigException(ioEx.getMessage());
         }
     }
 
@@ -86,13 +84,13 @@ public class GitRepo {
 
     private Path getRepoPath() {
         Path source = Paths.get("resources");
-        Path newFolder = Paths.get(source + File.separator + "configx" + File.separator);
+        Path newFolder = Paths.get(source + File.separator + "jsonConfig" + File.separator);
 
         return newFolder;
     }
 
-    @PreDestroy
-    public void deleteRepo() {
+
+    public void destroy() {
         Git.shutdown();
 
         try {

--- a/trial-config-service/src/main/java/uk/ac/ox/ndph/mts/trial_config_service/controller/TrialConfigController.java
+++ b/trial-config-service/src/main/java/uk/ac/ox/ndph/mts/trial_config_service/controller/TrialConfigController.java
@@ -67,6 +67,7 @@ public class TrialConfigController {
             byte[] fileBytes = gitRepo.getTrialFile(fileName);
             ObjectMapper objMapper = new ObjectMapper();
             trial = objMapper.readValue(fileBytes, Trial.class);
+            gitRepo.destroy();
         } catch (IOException ioException) {
             throw new InvalidConfigException(ioException.getMessage());
         }

--- a/trial-config-service/src/main/java/uk/ac/ox/ndph/mts/trial_config_service/controller/TrialConfigController.java
+++ b/trial-config-service/src/main/java/uk/ac/ox/ndph/mts/trial_config_service/controller/TrialConfigController.java
@@ -67,9 +67,10 @@ public class TrialConfigController {
             byte[] fileBytes = gitRepo.getTrialFile(fileName);
             ObjectMapper objMapper = new ObjectMapper();
             trial = objMapper.readValue(fileBytes, Trial.class);
-            gitRepo.destroy();
         } catch (IOException ioException) {
             throw new InvalidConfigException(ioException.getMessage());
+        } finally {
+            gitRepo.destroy();
         }
 
         return trial;

--- a/trial-config-service/src/test/java/uk/ac/ox/ndph/mts/trial_config_service/config/GitRepoTest.java
+++ b/trial-config-service/src/test/java/uk/ac/ox/ndph/mts/trial_config_service/config/GitRepoTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import uk.ac.ox.ndph.mts.trial_config_service.exception.InvalidConfigException;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -16,18 +17,18 @@ public class GitRepoTest {
     GitRepo gitRepo = new GitRepo();
 
     @BeforeAll
-    void setUp() throws GitAPIException, IOException {
+    void setUp() throws InvalidConfigException {
         gitRepo.init();
     }
 
     @Test
-    void getTrialFile() throws IOException {
+    void getTrialFile() throws InvalidConfigException {
         assertNotNull(gitRepo.getTrialFile("config.json"));
     }
 
     @AfterAll
-    void tearDown() throws IOException {
-        gitRepo.deleteRepo();
+    void tearDown() throws InvalidConfigException{
+        gitRepo.destroy();
     }
 
 }


### PR DESCRIPTION
Tidying exceptions, ensuring unix + windows file separator is used and force calling destroy as the java feedback via annotations isnt working..Ive tried lots of ways without luck..