### PR TITLE
ARTS-325 JsonSchema generator tool

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -7,5 +7,44 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>build-tools</artifactId>
     <version>1.0</version>
-
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.kjetland</groupId>
+            <artifactId>mbknor-jackson-jsonschema_2.10</artifactId>
+            <version>1.0.39</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <version>2.4.1</version>
+                <executions>
+                    <execution>
+                        <id>make-executable-jar-with-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addClasspath>true</addClasspath>
+                                    <mainClass>uk.ac.ox.ndph.mts.json_schema_generator.Main</mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>json-schema-generator</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/build-tools/src/main/java/META-INF/MANIFEST.MF
+++ b/build-tools/src/main/java/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: uk.ac.ox.ndph.mts.json_schema_generator.Main
+

--- a/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/Main.java
+++ b/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/Main.java
@@ -1,0 +1,29 @@
+package uk.ac.ox.ndph.mts.json_schema_generator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import uk.ac.ox.ndph.mts.json_schema_generator.model.TrialConfigFile;
+
+import java.io.File;
+import java.io.IOException;
+
+
+public final class Main {
+    static final String fileName = "jsonSchema.json";
+
+    public static void main(final String[] args) throws IOException, ClassNotFoundException {
+        SchemaGenerator jsonSchemaGenerator;
+
+        // Generate JsonSchema object
+        jsonSchemaGenerator = new SchemaGenerator(TrialConfigFile.class);
+        JsonNode jsonSchema = jsonSchemaGenerator.getJsonSchema();
+
+        // Write JsonSchema to file
+        ObjectMapper jsonObjectMapper = new ObjectMapper();
+
+        // Apply indentation
+        jsonObjectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        jsonObjectMapper.writeValue(new File(fileName), jsonSchema);
+    }
+}

--- a/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/README.md
+++ b/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/README.md
@@ -7,9 +7,9 @@
 
 ### Running the jsonSchema tool
 - Run the attached jar: `java -jar json-schema-generator.jar`
-- Alternatively,import the tool as a maven project and run the Main class.
+- Alternatively, import the tool as a maven project and run the Main class.
+- When compiling the project the jar file is created under 'target'.
 
 ## Modify the json schema
 - Under 'model' are the different POJOs that represent the trial config file definitions.
 - The main config file is **Model/TrialConfigFile**; When adding a new field to the configuration, add the POJO as a field in this class with the right json annotation.
-

--- a/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/README.md
+++ b/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/README.md
@@ -1,0 +1,15 @@
+# json-schema-generator
+
+- This tool generates jsonSchema DRAFT-07 from POJOs using Jackson @Annotations.
+- The jsonSchema is being written to the current directory as "JsonSchema.json".
+- This project uses [mbknor-jackson-jsonschema](https://github.com/mbknor/mbknor-jackson-jsonSchema) package.
+## Using this repository
+
+### Running the jsonSchema tool
+- Run the attached jar: `java -jar json-schema-generator.jar`
+- Alternatively,import the tool as a maven project and run the Main class.
+
+## Modify the json schema
+- Under 'model' are the different POJOs that represent the trial config file definitions.
+- The main config file is **Model/TrialConfigFile**; When adding a new field to the configuration, add the POJO as a field in this class with the right json annotation.
+

--- a/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/SchemaGenerator.java
+++ b/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/SchemaGenerator.java
@@ -1,0 +1,29 @@
+package uk.ac.ox.ndph.mts.json_schema_generator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kjetland.jackson.jsonSchema.JsonSchemaConfig;
+import com.kjetland.jackson.jsonSchema.JsonSchemaDraft;
+import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator;
+
+public class SchemaGenerator {
+
+    private final JsonNode jsonSchema;
+
+    public SchemaGenerator(final Class trailConfigFile) {
+        this.jsonSchema = generateJsonSchema(trailConfigFile);
+    }
+
+    private JsonNode generateJsonSchema(final Class trailConfigFile) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonSchemaConfig config = JsonSchemaConfig.vanillaJsonSchemaDraft4()
+                .withJsonSchemaDraft(JsonSchemaDraft.DRAFT_07);
+        JsonSchemaGenerator jsonSchemaGenerator =
+                new JsonSchemaGenerator(objectMapper, config);
+        return jsonSchemaGenerator.generateJsonSchema(trailConfigFile);
+    }
+
+    public JsonNode getJsonSchema() {
+        return jsonSchema;
+    }
+}

--- a/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/SchemaGenerator.java
+++ b/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/SchemaGenerator.java
@@ -16,6 +16,8 @@ public class SchemaGenerator {
 
     private JsonNode generateJsonSchema(final Class trailConfigFile) {
         ObjectMapper objectMapper = new ObjectMapper();
+
+        // The default json schema version of this library is DRAFT-04, which our validation action does not support. Hence, replaced with DRAFT-07.
         JsonSchemaConfig config = JsonSchemaConfig.vanillaJsonSchemaDraft4()
                 .withJsonSchemaDraft(JsonSchemaDraft.DRAFT_07);
         JsonSchemaGenerator jsonSchemaGenerator =

--- a/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/model/Service.java
+++ b/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/model/Service.java
@@ -1,0 +1,11 @@
+package uk.ac.ox.ndph.mts.json_schema_generator.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Service {
+    @JsonProperty(value = "image_name", required = true)
+    private String imageName;
+
+    @JsonProperty(value = "image_tag", required = true)
+    private String imageTag;
+}

--- a/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/model/SpringCloud.java
+++ b/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/model/SpringCloud.java
@@ -1,0 +1,14 @@
+package uk.ac.ox.ndph.mts.json_schema_generator.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SpringCloud {
+    @JsonProperty(value = "gateway_service", required = true)
+    private Service gatewayService;
+
+    @JsonProperty(value = "discovery_service", required = true)
+    private Service discoveryService;
+
+    @JsonProperty(value = "config_service", required = true)
+    private Service configService;
+}

--- a/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/model/TrialConfigFile.java
+++ b/build-tools/src/main/java/uk/ac/ox/ndph/mts/json_schema_generator/model/TrialConfigFile.java
@@ -1,0 +1,35 @@
+package uk.ac.ox.ndph.mts.json_schema_generator.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TrialConfigFile {
+    @JsonProperty(required = true)
+    private String name;
+
+    @JsonProperty(required = true)
+    private String id;
+
+    @JsonProperty(value = "tenant_id", required = true)
+    private String tenantId;
+
+    @JsonProperty(value = "ui_client_id", required = true)
+    private String uiClientId;
+
+    @JsonProperty(required = true, defaultValue = "1")
+    private int version;
+
+    @JsonProperty(required = true)
+    private String rootUser;
+
+    @JsonProperty(value = "site_service", required = true)
+    private Service siteService;
+
+    @JsonProperty(value = "practitioner_service", required = true)
+    private Service practitionerService;
+
+    @JsonProperty(value = "config_server_service", required = true)
+    private Service configServerService;
+
+    @JsonProperty(value = "spring_cloud", required = true)
+    private SpringCloud springCloud;
+}


### PR DESCRIPTION
## Description
Java code of jsonSchema generator, including a jar file and a README file that explains the use of the tool.

### Changes
- [ART-325] - Build data entities for the json schema- all relevant models are under model folder, perhaps in the future we will want to create a consistency between the trial config models and the models that are necessary today for the terraform generation.

### Checklist:

- [x] Jar that can be writes the jsonSchema file in current directory
- [x] Models that describe the current terraform definition.json file
- [x] README file that explains how to use the tool
