### PR TITLE
Removed the azure.version from the practitioner-service

### DIFF
--- a/practitioner-service/pom.xml
+++ b/practitioner-service/pom.xml
@@ -16,7 +16,6 @@
         it as a FHIR practitioner entity to the FHIR store.
     </description>
     <properties>
-        <azure.version>2.3.5</azure.version>
         <hapifhir.version>5.0.2</hapifhir.version>
     </properties>
 


### PR DESCRIPTION
Removed the azure.version from the practitioner-service, for a few reasons:

1. practitioner-service doesn't appear to use this variable
2. it already inherits azure.version from the parent POM
3. we probably don't want to accidentally end up overriding the parent POM's azure.version - I'm guessing we always want them to be the same. Declaring it in a couple of places increases risk of the values deviating.

There is no linked ARTS story for this.

As this is Azure-related, I'm not certain how to test if this has broken something or not. It successfully builds under Maven (i.e. the tests pass) and "docker-compose up" still gets the system up & running locally.