### PR TITLE
Refactor Practitioner Service API tests

### DIFF
--- a/api-tests/data/practitioner-service/createperson.js
+++ b/api-tests/data/practitioner-service/createperson.js
@@ -3,7 +3,6 @@ const validPerson = {
     "givenName": "Cookie",
     "familyName": "Cookie"
 }
-module.exports.validPerson = validPerson;
 
 const missingPrefix = {
     "prefix": "",
@@ -11,15 +10,11 @@ const missingPrefix = {
     "familyName": "familyName"
 }
 
-module.exports.missingPrefix = missingPrefix;
-
 const missingGivenName = {
     "prefix": "prefix",
     "givenName": "",
     "familyName": "familyName"
 }
-
-module.exports.missingGivenName = missingGivenName;
 
 const missingfamilyName = {
     "prefix": "prefix",
@@ -27,23 +22,17 @@ const missingfamilyName = {
     "familyName": ""
 }
 
-module.exports.missingfamilyName = missingfamilyName;
-
 const invalidCharacterLength = {
     "prefix": "qwertyuioplkjhgfdsazxcvbnmqwertyuiw",
     "givenName": "qwertyuioplkjhgfdsazxcvbnmqwertyuiw",
     "familyName": "ghfghdfgdhfgdhgfdhfgdhgfhdgfhdgfhdgfdhgfhdgfhdgfhdgfhfgdhfgdhf"
 }
 
-module.exports.invalidCharacterLength = invalidCharacterLength;
-
 const illegalCharacters = {
     "prefix": "M@£$S",
     "givenName": "S£$%T@@$E",
     "familyName": "P*(&)(*!£~D"
 }
-
-module.exports.illegalCharacters = illegalCharacters;
 
 const malformedJson = {
     "\prefix": "\M@£$S",
@@ -52,4 +41,12 @@ const malformedJson = {
 }
 
 
-module.exports.malformedJson = malformedJson;   
+module.exports = {
+    validPerson,
+    missingPrefix,
+    missingGivenName,
+    missingfamilyName,
+    invalidCharacterLength,
+    illegalCharacters,
+    malformedJson
+};   

--- a/api-tests/specs/practitioner-service/createperson.js
+++ b/api-tests/specs/practitioner-service/createperson.js
@@ -1,4 +1,4 @@
-const { validPerson, invalidCharacterLength, missingGivenName, missingfamilyName, missingPrefix, illegalCharacters, malformedJson } = require('../../data/practitioner-service/createperson')
+const requests = require('../../data/practitioner-service/createperson')
 const conf = require('../../config/conf')
 
 beforeEach(function () {
@@ -8,42 +8,43 @@ beforeEach(function () {
 describe('As a user with Create Person permission, I want to have my create person request validated by the system, So that I cannot create an invalid person', function () {
 
     it('When I submit an API request to create a Person with a value for all mandatory fields and no fields exceed their specified maximum length, Then a new Person record is persisted in the system with a unique identifier And I receive a success acknowledgement', async () => {
-        const response = await baseRequest.post('/practitioner').send(validPerson);
+        const response = await baseRequest.post('/practitioner').send(requests.validPerson);
         expect(response.text).to.contain("id")
-        expect(response.status).to.equal(201)
+        expect(response.status).to.equal(HttpStatus.CREATED)
     });
 
     it('When I submit an API request to create a Person with missing non-mandatory prefix field, Then a new Person record is persisted in the system with a unique identifier And I receive a success acknowledgement', async () => {
-        const response = await baseRequest.post("/practitioner").send(missingPrefix);
+        const response = await baseRequest.post("/practitioner").send(requests.missingPrefix);
         expect(response.text).to.contain("id")
-        expect(response.status).to.equal(201)
+        expect(response.status).to.equal(HttpStatus.CREATED)
     });
 
     it('When I submit an API request to create a Person with missing non-mandatory givenName field, Then a new Person record is persisted in the system with a unique identifier And I receive a success acknowledgement', async () => {
-        const response = await baseRequest.post("/practitioner").send(missingGivenName);
+        const response = await baseRequest.post("/practitioner").send(requests.missingGivenName);
         expect(response.text).to.contain("id")
-        expect(response.status).to.equal(201)
+        expect(response.status).to.equal(HttpStatus.CREATED)
     });
 
     it('When I submit an API request to create a Person with missing manadatory familyName field, Then a new Person record is not created And I receive an error notification', async () => {
-        const response = await baseRequest.post("/practitioner").send(missingfamilyName);
+        const response = await baseRequest.post("/practitioner").send(requests.missingfamilyName);
+        expect(response.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
         expect(response.text).to.contain("argument Family Name failed validation")
     });
 
     it('When I submit an API request to create a Person with any fields exceeding their specified maximum length, Then a new Person record is not created And I receive an error notification', async () => {
-        const response = await baseRequest.post("/practitioner").send(invalidCharacterLength);
-        expect(response.status).to.equal(422)
+        const response = await baseRequest.post("/practitioner").send(requests.invalidCharacterLength);
+        expect(response.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
         expect(response.text).to.contain("argument Family Name failed validation")
     });
 
     it('When I submit an API request to create a Person with any fields holding illegal characters, Then a new Person record is not created And I receive an error notification', async () => {
-        const response = await baseRequest.post("/practitioner").send(illegalCharacters);
-        expect(response.status).to.equal(422)
+        const response = await baseRequest.post("/practitioner").send(requests.illegalCharacters);
+        expect(response.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
         expect(response.text).to.contain("argument Prefix failed validation")
     });
 
     it('When I submit an API request to create a Person with a malformed JSON, Then a new Person record is not created And I receive an error notification', async () => {
-        const response = await baseRequest.post("/practitioner").send(malformedJson);
-        expect(response.status).to.equal(422)
+        const response = await baseRequest.post("/practitioner").send(requests.malformedJson);
+        expect(response.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
     });
 });


### PR DESCRIPTION
The pr has changes made to the practitioner services api tests. I have updated the following

1. The response status is asserted using the status error message along with the code.
2. The way the data is pulled from the .js file.

**Note:** No jira ticket is created for this one