### PR TITLE
[ARTS-465] A basic implementation for assigning roles to users

### DIFF
--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/configuration/Configurations.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/configuration/Configurations.java
@@ -4,7 +4,7 @@ package uk.ac.ox.ndph.mts.practitioner_service.configuration;
  * String constants
  */
 public enum Configurations {
-    ERROR("Error while loading configuration file");
+    ERROR("Error loading configuration file");
 
     private String message;
  

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/controller/PractitionerController.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/controller/PractitionerController.java
@@ -1,12 +1,15 @@
 package uk.ac.ox.ndph.mts.practitioner_service.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
 import uk.ac.ox.ndph.mts.practitioner_service.model.Practitioner;
+import uk.ac.ox.ndph.mts.practitioner_service.model.RoleAssignment;
 import uk.ac.ox.ndph.mts.practitioner_service.model.Response;
 import uk.ac.ox.ndph.mts.practitioner_service.service.EntityService;
 
@@ -14,15 +17,12 @@ import uk.ac.ox.ndph.mts.practitioner_service.service.EntityService;
  * Controller for practitioner endpoint of practitioner-service
  */
 @RestController
+@RequestMapping(path = "/practitioner", consumes = "application/json", produces = "application/json")
 public class PractitionerController {
-
-    private static final String ENDPOINT_PATH = "/practitioner";
-    private static final String APPLICATION_JSON = "application/json";
 
     private final EntityService entityService;
 
     /**
-     *
      * @param entityService validate and save the practitioner
      */
     @Autowired
@@ -31,13 +31,20 @@ public class PractitionerController {
     }
 
     /**
-     *
-     * @param practitioner
+     * @param practitioner The practitioner to create
      * @return ResponseEntity
      */
-    @PostMapping(path = ENDPOINT_PATH, consumes = APPLICATION_JSON, produces = APPLICATION_JSON)
-    public ResponseEntity<Response> practitioner(@RequestBody Practitioner practitioner) {
+    @PostMapping()
+    public ResponseEntity<Response> savePractitioner(@RequestBody Practitioner practitioner) {
         String practitionerId = entityService.savePractitioner(practitioner);
         return ResponseEntity.status(HttpStatus.CREATED).body(new Response(practitionerId));
+    }
+
+    @PostMapping(path = "/{practitionerId}/roles")
+    public ResponseEntity<Response> saveRoleAssignment(@PathVariable String practitionerId,
+                                                       @RequestBody RoleAssignment roleAssignment) {
+        roleAssignment.setPractitionerId(practitionerId);
+        String roleAssignmentId = entityService.saveRoleAssignment(roleAssignment);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new Response(roleAssignmentId));
     }
 }

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/converter/RoleAssignmentConverter.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/converter/RoleAssignmentConverter.java
@@ -1,0 +1,28 @@
+package uk.ac.ox.ndph.mts.practitioner_service.converter;
+
+import org.hl7.fhir.r4.model.Reference;
+import org.springframework.stereotype.Component;
+import uk.ac.ox.ndph.mts.practitioner_service.model.RoleAssignment;
+
+/**
+ * Implement an EntityConverter for RoleAssignment
+ */
+@Component
+public class RoleAssignmentConverter implements EntityConverter<RoleAssignment,
+        org.hl7.fhir.r4.model.PractitionerRole> {
+
+    /**
+     * Convert an MTS PractitionerRole to an hl7 model PractitionerRole.
+     *
+     * @param input the MTS PractitionerRole to convert.
+     * @return org.hl7.fhir.r4.model.PractitionerRole
+     */
+    public org.hl7.fhir.r4.model.PractitionerRole convert(RoleAssignment input) {
+        org.hl7.fhir.r4.model.PractitionerRole fhirPractitionerRole = new org.hl7.fhir.r4.model.PractitionerRole();
+        fhirPractitionerRole.setOrganization(new Reference("Organization/" + input.getSiteId()));
+        fhirPractitionerRole.setPractitioner(new Reference("Practitioner/" + input.getPractitionerId()));
+        fhirPractitionerRole.addCode().setText(input.getRoleId());
+
+        return fhirPractitionerRole;
+    }
+}

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/converter/RoleAssignmentConverter.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/converter/RoleAssignmentConverter.java
@@ -12,7 +12,7 @@ public class RoleAssignmentConverter implements EntityConverter<RoleAssignment,
         org.hl7.fhir.r4.model.PractitionerRole> {
 
     /**
-     * Convert an MTS PractitionerRole to an hl7 model PractitionerRole.
+     * Convert a RoleAssignment to an hl7 model PractitionerRole.
      *
      * @param input the MTS PractitionerRole to convert.
      * @return org.hl7.fhir.r4.model.PractitionerRole

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/model/RoleAssignment.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/model/RoleAssignment.java
@@ -1,0 +1,39 @@
+package uk.ac.ox.ndph.mts.practitioner_service.model;
+
+public class RoleAssignment {
+
+    private String practitionerId;
+    private String siteId;
+    private String roleId;
+
+    public RoleAssignment(String practitionerId, String siteId, String roleId) {
+        this.practitionerId = practitionerId;
+        this.siteId = siteId;
+        this.roleId = roleId;
+    }
+
+    public String getPractitionerId() {
+        return practitionerId;
+    }
+
+    public void setPractitionerId(String practitionerId) {
+        this.practitionerId = practitionerId;
+    }
+
+    public String getSiteId() {
+        return siteId;
+    }
+
+    public void setSiteId(String siteId) {
+        this.siteId = siteId;
+    }
+
+    public String getRoleId() {
+        return roleId;
+    }
+
+    public void setRoleId(String roleId) {
+        this.roleId = roleId;
+    }
+
+}

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/FhirContextWrapper.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/FhirContextWrapper.java
@@ -60,20 +60,4 @@ public class FhirContextWrapper {
         return new ArrayList<>(BundleUtil.toListOfResources(fhirContext, bundle));
     }
 
-//    public <T> IBaseResource readWithId(String id, Class<T> classType) {
-//        var client = fhirContext.newRestfulGenericClient("");
-//
-//        return client.read()
-//                .resource(classType.getName())
-//                .withId(id)
-//                .execute();
-//    }
-
-//    public Practitioner readPractitionerWithId(String id) {
-//        var client = fhirContext.newRestfulGenericClient(fhirUri);
-//        return client.read()
-//                .resource(Practitioner.class)
-//                .withId(id)
-//                .execute();
-//    }
 }

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/FhirContextWrapper.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/FhirContextWrapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import ca.uhn.fhir.context.FhirContext;
@@ -17,41 +18,62 @@ import ca.uhn.fhir.util.BundleUtil;
 public class FhirContextWrapper {
     private final FhirContext fhirContext;
 
+    @SuppressWarnings("FieldMayBeFinal") // Value injection shouldn't be final
+    @Value("${fhir.uri}")
+    private String fhirUri = "";
+
     /**
      * constructor
-     */ 
+     */
     public FhirContextWrapper() {
         fhirContext = FhirContext.forR4();
     }
-    
+
     /**
      * Pretty print a resource
+     *
      * @param resource the resource to print
-     * @return the pretty print String of the resource 
+     * @return the pretty print String of the resource
      */
     public String prettyPrint(IBaseResource resource) {
-        return  fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(resource);
+        return fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(resource);
     }
 
     /**
      * Execute a bundle transaction to a FHIR endpoint
-     * @param uri the FHIR endpoint URI
+     *
      * @param input the Bundle to save
      * @return the returned Bundle object from FHIR endpoint
      */
-    public Bundle executeTrasaction(String uri, Bundle input) {
-        return fhirContext.newRestfulGenericClient(uri).transaction()
-                    .withBundle(input).execute();
+    public Bundle executeTransaction(Bundle input) {
+        return fhirContext.newRestfulGenericClient(fhirUri).transaction()
+                .withBundle(input).execute();
     }
 
     /**
      * Extracts a list of resources from a bundle
+     *
      * @param bundle the bundle to extract
      * @return the list of resources in the bundle
      */
     public List<IBaseResource> toListOfResources(Bundle bundle) {
-        List<IBaseResource> resp = new ArrayList<>();
-        resp.addAll(BundleUtil.toListOfResources(fhirContext, bundle));
-        return resp;
+        return new ArrayList<>(BundleUtil.toListOfResources(fhirContext, bundle));
     }
+
+//    public <T> IBaseResource readWithId(String id, Class<T> classType) {
+//        var client = fhirContext.newRestfulGenericClient("");
+//
+//        return client.read()
+//                .resource(classType.getName())
+//                .withId(id)
+//                .execute();
+//    }
+
+//    public Practitioner readPractitionerWithId(String id) {
+//        var client = fhirContext.newRestfulGenericClient(fhirUri);
+//        return client.read()
+//                .resource(Practitioner.class)
+//                .withId(id)
+//                .execute();
+//    }
 }

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/FhirRepo.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/FhirRepo.java
@@ -4,8 +4,8 @@ package uk.ac.ox.ndph.mts.practitioner_service.repository;
  * String constants
  */
 public enum FhirRepo {
-    SAVE_REQUEST("request to fhir: %s"),
-    SAVE_RESPONSE("response from fhir: %s"),
+    SAVE_REQUEST("request to fhir: {}"),
+    SAVE_RESPONSE("response from fhir: {}"),
     UPDATE_ERROR("error while updating fhir store"),
     BAD_RESPONSE_SIZE("bad response size from FHIR: %d");
 

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/FhirRepo.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/FhirRepo.java
@@ -4,7 +4,7 @@ package uk.ac.ox.ndph.mts.practitioner_service.repository;
  * String constants
  */
 public enum FhirRepo {
-    SAVE_PRACTITIONER("request to fhir: %s"),
+    SAVE_REQUEST("request to fhir: %s"),
     SAVE_RESPONSE("response from fhir: %s"),
     UPDATE_ERROR("error while updating fhir store"),
     BAD_RESPONSE_SIZE("bad response size from FHIR: %d");

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/FhirRepository.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/FhirRepository.java
@@ -1,6 +1,7 @@
 package uk.ac.ox.ndph.mts.practitioner_service.repository;
 
 import org.hl7.fhir.r4.model.Practitioner;
+import org.hl7.fhir.r4.model.PractitionerRole;
 
 /**
  * Interface for a FHIR entity repository
@@ -14,4 +15,6 @@ public interface FhirRepository {
      * @return Nothing.
      */
     String savePractitioner(Practitioner practitioner);
+
+    String savePractitionerRole(PractitionerRole practitionerRole);
 }

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/HapiFhirRepository.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/HapiFhirRepository.java
@@ -3,6 +3,7 @@ package uk.ac.ox.ndph.mts.practitioner_service.repository;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.PractitionerRole;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.hl7.fhir.r4.model.Resource;
@@ -18,11 +19,10 @@ import uk.ac.ox.ndph.mts.practitioner_service.exception.RestException;
 @Component
 public class HapiFhirRepository implements FhirRepository {
 
-    private static final String PRACTITIONER_ENTITY_NAME = "Practitioner";
-
     private final FhirContextWrapper fhirContextWrapper;
     private final Logger logger = LoggerFactory.getLogger(HapiFhirRepository.class);
 
+    @SuppressWarnings("FieldMayBeFinal") // Value injection shouldn't be final
     @Value("${fhir.uri}")
     private String fhirUri = "";
 
@@ -37,14 +37,12 @@ public class HapiFhirRepository implements FhirRepository {
     public String savePractitioner(Practitioner practitioner) {
         // Log the request
         if (logger.isInfoEnabled()) {
-            logger.info(FhirRepo.SAVE_PRACTITIONER.message(),
-                fhirContextWrapper.prettyPrint(practitioner));
+            logger.info(FhirRepo.SAVE_REQUEST.message(), fhirContextWrapper.prettyPrint(practitioner));
         }
 
         Bundle responseBundle;
         try {
-            responseBundle = fhirContextWrapper.executeTrasaction(fhirUri, 
-                bundle(practitioner, PRACTITIONER_ENTITY_NAME));
+            responseBundle = fhirContextWrapper.executeTransaction(bundle(practitioner));
         } catch (BaseServerResponseException e) {
             logger.warn(FhirRepo.UPDATE_ERROR.message(), e);
             throw new RestException(e.getMessage(), e);
@@ -53,30 +51,58 @@ public class HapiFhirRepository implements FhirRepository {
 
         // Log the response
         if (logger.isInfoEnabled()) {
-            logger.info(FhirRepo.SAVE_RESPONSE.message(),
-                    fhirContextWrapper.prettyPrint(responseElement));
+            logger.info(FhirRepo.SAVE_RESPONSE.message(), fhirContextWrapper.prettyPrint(responseElement));
         }
+
+        //TODO: replace with the actual id return
         return practitioner.getIdElement().getValue();
     }
+
+    @Override
+    public String savePractitionerRole(PractitionerRole practitionerRole) {
+        // Log the request
+        if (logger.isInfoEnabled()) {
+            logger.info(fhirContextWrapper.prettyPrint(practitionerRole));
+        }
+
+        Bundle responseBundle;
+        try {
+            responseBundle = fhirContextWrapper.executeTransaction(bundle(practitionerRole));
+        } catch (BaseServerResponseException e) {
+            logger.warn(FhirRepo.UPDATE_ERROR.message(), e);
+            throw new RestException(e.getMessage(), e);
+        }
+        IBaseResource responseElement = extractResponseResource(responseBundle);
+
+        // Log the response
+        if (logger.isInfoEnabled()) {
+            logger.info(FhirRepo.SAVE_RESPONSE.message(), fhirContextWrapper.prettyPrint(responseElement));
+        }
+
+        return responseElement.getIdElement().getIdPart();
+    }
+
     private IBaseResource extractResponseResource(Bundle bundle) throws RestException {
         var resp = fhirContextWrapper.toListOfResources(bundle);
-        
+
         if (resp.size() != 1) {
             logger.info(FhirRepo.BAD_RESPONSE_SIZE.message(), resp.size());
-            throw new RestException(String.format(
-                FhirRepo.BAD_RESPONSE_SIZE.message(), resp.size()));
-
+            throw new RestException(String.format(FhirRepo.BAD_RESPONSE_SIZE.message(), resp.size()));
         }
         return resp.get(0);
     }
 
-    private Bundle bundle(Resource resource, String resourceName) {
+    private Bundle bundle(Resource resource) {
         Bundle bundle = new Bundle();
-        bundle.setType(Bundle.BundleType.TRANSACTION);
+        bundle.setType(Bundle.BundleType.TRANSACTION); // we use a single resource bundle, do we need this?
 
-        // Add the practitioner as an entry.
-        bundle.addEntry().setFullUrl(resource.getIdElement().getValue()).setResource(resource).getRequest()
-                .setUrl(resourceName).setMethod(Bundle.HTTPVerb.POST);
+        // Add the resource as an entry.
+        bundle.addEntry()
+                .setFullUrl(resource.getIdElement().getValue())
+                .setResource(resource)
+                .getRequest()
+                .setUrl(resource.fhirType())
+                .setMethod(Bundle.HTTPVerb.POST);
         return bundle;
     }
 }

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/RoleAssignmentStore.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/repository/RoleAssignmentStore.java
@@ -1,0 +1,33 @@
+package uk.ac.ox.ndph.mts.practitioner_service.repository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.ac.ox.ndph.mts.practitioner_service.converter.EntityConverter;
+import uk.ac.ox.ndph.mts.practitioner_service.model.RoleAssignment;
+
+/**
+ * Implement an EntityStore for RoleAssignment.
+ */
+@Component
+public class RoleAssignmentStore implements EntityStore<RoleAssignment> {
+
+
+    private final FhirRepository repository;
+    private final EntityConverter<RoleAssignment, org.hl7.fhir.r4.model.PractitionerRole> converter;
+
+    /**
+     * @param repository - The fhir repository
+     * @param converter - a model-entity to fhir-entity converter
+     */
+    @Autowired
+    public RoleAssignmentStore(FhirRepository repository,
+                               EntityConverter<RoleAssignment, org.hl7.fhir.r4.model.PractitionerRole> converter) {
+        this.repository = repository;
+        this.converter = converter;
+    }
+
+    @Override
+    public String saveEntity(RoleAssignment entity) {
+        return repository.savePractitionerRole(converter.convert(entity));
+    }
+}

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/service/EntityService.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/service/EntityService.java
@@ -1,6 +1,7 @@
 package uk.ac.ox.ndph.mts.practitioner_service.service;
 
 import uk.ac.ox.ndph.mts.practitioner_service.model.Practitioner;
+import uk.ac.ox.ndph.mts.practitioner_service.model.RoleAssignment;
 
 /**
  * Interface for validating and saving an entity
@@ -14,4 +15,6 @@ public interface EntityService {
      * @return the id of the created entity.
      */
     String savePractitioner(Practitioner practitioner);
+
+    String saveRoleAssignment(RoleAssignment roleAssignment);
 }

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/service/PractitionerService.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/service/PractitionerService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import uk.ac.ox.ndph.mts.practitioner_service.exception.InitialisationError;
 import uk.ac.ox.ndph.mts.practitioner_service.exception.ValidationException;
 import uk.ac.ox.ndph.mts.practitioner_service.model.Practitioner;
+import uk.ac.ox.ndph.mts.practitioner_service.model.RoleAssignment;
+import uk.ac.ox.ndph.mts.practitioner_service.model.ValidationResponse;
 import uk.ac.ox.ndph.mts.practitioner_service.repository.EntityStore;
 import uk.ac.ox.ndph.mts.practitioner_service.validation.ModelEntityValidation;
 
@@ -19,39 +21,65 @@ import uk.ac.ox.ndph.mts.practitioner_service.validation.ModelEntityValidation;
 @Service
 public class PractitionerService implements EntityService {
 
-    private EntityStore<Practitioner> practitionerStore;
-    private final ModelEntityValidation<Practitioner> entityValidation;
+    private final EntityStore<Practitioner> practitionerStore;
+    private final ModelEntityValidation<Practitioner> practitionerValidator;
+    @SuppressWarnings("FieldCanBeLocal")
     private final Logger logger = LoggerFactory.getLogger(PractitionerService.class);
 
+    private final EntityStore<RoleAssignment> roleAssignmentStore;
+    private final ModelEntityValidation<RoleAssignment> roleAssignmentValidator;
+
     /**
-     *
      * @param practitionerStore Practitioner store interface
-     * @param entityValidation Practitioner validation interface 
+     * @param practitionerValidator Practitioner validation interface
      */
     @Autowired
     public PractitionerService(EntityStore<Practitioner> practitionerStore,
-            ModelEntityValidation<Practitioner> entityValidation) {
+                               ModelEntityValidation<Practitioner> practitionerValidator,
+                               EntityStore<RoleAssignment> roleAssignmentStore,
+                               ModelEntityValidation<RoleAssignment> roleAssignmentValidator) {
         if (practitionerStore == null) {
             throw new InitialisationError("practitioner store cannot be null");
         }
-        if (entityValidation == null) {
-            throw new InitialisationError("entity validation cannot be null");
+        if (practitionerValidator == null) {
+            throw new InitialisationError("practitioner entity validation cannot be null");
         }
+        if (roleAssignmentStore == null) {
+            throw new InitialisationError("RoleAssignment store cannot be null");
+        }
+        if (roleAssignmentValidator == null) {
+            throw new InitialisationError("RoleAssignment entity validation cannot be null");
+        }
+
         this.practitionerStore = practitionerStore;
-        this.entityValidation = entityValidation;
+        this.practitionerValidator = practitionerValidator;
+
+        this.roleAssignmentStore = roleAssignmentStore;
+        this.roleAssignmentValidator = roleAssignmentValidator;
+
         logger.info(Services.STARTUP.message());
     }
 
     /**
-     *
      * @param practitioner the Practitioner to save.
      * @return The id of the new practitioner
      */
     public String savePractitioner(Practitioner practitioner) {
-        var validationResponse = entityValidation.validate(practitioner);
+        var validationResponse = practitionerValidator.validate(practitioner);
         if (!validationResponse.isValid()) {
             throw new ValidationException(validationResponse.getErrorMessage());
         }
         return practitionerStore.saveEntity(practitioner);
+    }
+
+    //TODO: should this be on its own service?
+    @Override
+    public String saveRoleAssignment(RoleAssignment roleAssignment) {
+        //TODO: validate(?) that referenced IDs properties exist in the system
+        ValidationResponse validationResponse = roleAssignmentValidator.validate(roleAssignment);
+        if (!validationResponse.isValid()) {
+            throw new ValidationException(validationResponse.getErrorMessage());
+        }
+        return roleAssignmentStore.saveEntity(roleAssignment);
     }
 }

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/validation/PractitionerValidation.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/validation/PractitionerValidation.java
@@ -38,6 +38,7 @@ public class PractitionerValidation implements ModelEntityValidation<Practitione
     private static final String REGEX_ALL = ".*";
 
     private final Map<Attribute, AttributeData> validationMap;
+    @SuppressWarnings("FieldCanBeLocal")
     private final Logger logger = LoggerFactory.getLogger(PractitionerValidation.class);
 
     /**
@@ -54,7 +55,7 @@ public class PractitionerValidation implements ModelEntityValidation<Practitione
                                 pair.getRight().getGetValue())));
 
         validateMap();
-        logger.info(Validations.STARTUP.message(), configuration);
+        logger.info(Validations.STARTUP.message(), "Practitioner", configuration);
     }
 
     @Override

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/validation/RoleAssignmentValidation.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/validation/RoleAssignmentValidation.java
@@ -36,7 +36,7 @@ public class RoleAssignmentValidation implements ModelEntityValidation<RoleAssig
         return new ValidationResponse(true, "");
     }
 
-    private Boolean isNullOrBlank(String str) {
+    private boolean isNullOrBlank(String str) {
         return str == null || str.isBlank();
     }
 

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/validation/RoleAssignmentValidation.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/validation/RoleAssignmentValidation.java
@@ -1,0 +1,43 @@
+package uk.ac.ox.ndph.mts.practitioner_service.validation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.ac.ox.ndph.mts.practitioner_service.model.RoleAssignment;
+import uk.ac.ox.ndph.mts.practitioner_service.model.ValidationResponse;
+
+/**
+ * Implements a ModelEntityValidation for RoleAssignment
+ */
+@Component
+public class RoleAssignmentValidation implements ModelEntityValidation<RoleAssignment> {
+
+    @SuppressWarnings("FieldCanBeLocal")
+    private final Logger logger = LoggerFactory.getLogger(RoleAssignmentValidation.class);
+
+    @Autowired
+    public RoleAssignmentValidation() {
+        logger.info(Validations.STARTUP.message(), "RoleAssignment", "");
+    }
+
+    @Override
+    public ValidationResponse validate(RoleAssignment entity) {
+        if (isNullOrBlank(entity.getPractitionerId())) {
+            return new ValidationResponse(false, "practitionerId must have a value");
+        }
+        if (isNullOrBlank(entity.getSiteId())) {
+            return new ValidationResponse(false, "siteId must have a value");
+        }
+        if (isNullOrBlank(entity.getRoleId())) {
+            return new ValidationResponse(false, "roleId must have a value");
+        }
+
+        return new ValidationResponse(true, "");
+    }
+
+    private Boolean isNullOrBlank(String str) {
+        return str == null || str.isBlank();
+    }
+
+}

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/validation/Validations.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/validation/Validations.java
@@ -4,7 +4,7 @@ package uk.ac.ox.ndph.mts.practitioner_service.validation;
  * String constants
  */
 public enum Validations {
-    STARTUP("Laoded practitioner validation with configuration: {}"),
+    STARTUP("Loaded {} validation with configuration: {}"),
     ERROR("argument %s failed validation");
 
     private String message;

--- a/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/PractitionerServiceIntegrationTests.java
+++ b/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/PractitionerServiceIntegrationTests.java
@@ -1,6 +1,7 @@
 package uk.ac.ox.ndph.mts.practitioner_service;
 
 import org.hl7.fhir.r4.model.Practitioner;
+import org.hl7.fhir.r4.model.PractitionerRole;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -32,6 +33,9 @@ class PractitionerServiceIntegrationTests {
     @MockBean
     public FhirRepository repository;
 
+    private final String practitionerUri = "/practitioner";
+    private final String roleAssignmentUri = "/practitioner/987/roles";
+
     @Test
     void TestPostPractitioner_WhenValidInput_Returns201AndId() throws Exception {
         // Arrange
@@ -41,7 +45,7 @@ class PractitionerServiceIntegrationTests {
         String jsonString = "{\"prefix\": \"prefix\", \"givenName\": \"givenName\", \"familyName\": \"familyName\"}";
         // Act + Assert
         this.mockMvc
-                .perform(post("/practitioner").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(practitionerUri).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isCreated()).andExpect(content().string(containsString("123")));
     }
 
@@ -54,7 +58,7 @@ class PractitionerServiceIntegrationTests {
         String jsonString = "{\"prefix\": \"prefix\", \"givenName\": \"\", \"familyName\": \"familyName\"}";
         // Act + Assert
         var error = this.mockMvc
-                .perform(post("/practitioner").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(practitionerUri).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isUnprocessableEntity()).andReturn().getResolvedException().getMessage();
         assertThat(error, containsString("Given Name"));
     }
@@ -68,8 +72,22 @@ class PractitionerServiceIntegrationTests {
         String jsonString = "{\"prefix\": \"prefix\", \"givenName\": \"givenName\", \"familyName\": \"familyName\"}";
         // Act + Assert
         var error = this.mockMvc
-                .perform(post("/practitioner").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(practitionerUri).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isBadGateway()).andReturn().getResolvedException().getMessage();
         assertThat(error, containsString("test error"));
+    }
+
+
+    @Test
+    void TestPostRoleAssignment_WhenValidInput_Returns201AndId() throws Exception {
+        // Arrange
+        when(repository.savePractitionerRole(any(PractitionerRole.class))).thenReturn("123");
+
+
+        String jsonString = "{\"siteId\": \"siteId\", \"roleId\": \"roleId\"}";
+        // Act + Assert
+        this.mockMvc
+                .perform(post(roleAssignmentUri).contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .andDo(print()).andExpect(status().isCreated()).andExpect(content().string(containsString("123")));
     }
 }

--- a/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/controller/PractitionerControllerTests.java
+++ b/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/controller/PractitionerControllerTests.java
@@ -8,21 +8,22 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.http.MediaType;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.when;
 import org.mockito.Mockito;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.on;
+import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder;
 import uk.ac.ox.ndph.mts.practitioner_service.model.Practitioner;
+import uk.ac.ox.ndph.mts.practitioner_service.model.RoleAssignment;
 import uk.ac.ox.ndph.mts.practitioner_service.service.EntityService;
 import uk.ac.ox.ndph.mts.practitioner_service.exception.RestException;
 import uk.ac.ox.ndph.mts.practitioner_service.exception.ValidationException;
 
-@SpringBootTest(properties = { "server.error.include-message=always" })
+@SpringBootTest(properties = {"server.error.include-message=always"})
 @AutoConfigureMockMvc
 class PractitionerControllerTests {
     @Autowired
@@ -32,10 +33,9 @@ class PractitionerControllerTests {
     private EntityService entityService;
 
     @Test
-    void TestPostPractitioner_WhenNoInput_Returns400() throws Exception {
-
+    void TestPostPractitioner_WhenNoBody_Returns400() throws Exception {
         // Act + Assert
-        this.mockMvc.perform(post("/practitioner").contentType(MediaType.APPLICATION_JSON))
+        this.mockMvc.perform(post(getPractitionerUri()).contentType(MediaType.APPLICATION_JSON))
                 .andDo(print()).andExpect(status().isBadRequest());
     }
 
@@ -46,7 +46,7 @@ class PractitionerControllerTests {
         String jsonString = "{\"prefix\": \"prefix\", \"givenName\": \"givenName\", \"familyName\": \"familyName\"}";
         // Act + Assert
         this.mockMvc
-                .perform(post("/practitioner").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(getPractitionerUri()).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isCreated()).andExpect(content().string(containsString("123")));
     }
 
@@ -57,7 +57,7 @@ class PractitionerControllerTests {
         String jsonString = "{\"givenName\": \"givenName\", \"familyName\": \"familyName\"}";
         // Act + Assert
         this.mockMvc
-                .perform(post("/practitioner").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(getPractitionerUri()).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isCreated()).andExpect(content().string(containsString("123")));
     }
 
@@ -69,7 +69,7 @@ class PractitionerControllerTests {
 
         // Act + Assert
         this.mockMvc
-                .perform(post("/practitioner").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(getPractitionerUri()).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isBadGateway());
     }
 
@@ -81,8 +81,58 @@ class PractitionerControllerTests {
 
         // Act + Assert
         String error = this.mockMvc
-                .perform(post("/practitioner").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(getPractitionerUri()).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isUnprocessableEntity()).andReturn().getResolvedException().getMessage();
         assertThat(error, containsString("prefix"));
     }
+
+    private String getPractitionerUri() {
+        return MvcUriComponentsBuilder.fromMethodCall(on(PractitionerController.class)
+                .savePractitioner(null)).build().toUriString();
+    }
+
+
+    // RoleAssignment Tests
+
+    @Test
+    void TestPostRoleAssignment_WhenNoBody_Returns400() throws Exception {
+        // Act + Assert
+        this.mockMvc.perform(post(getRoleAssignmentUri()).contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void TestPostRoleAssignment_WhenPartialInput_Returns201AndId() throws Exception {
+        // We test that the controller doesn't do any logic
+        // Arrange
+        String returnedValue = "123";
+        when(entityService.saveRoleAssignment(Mockito.any(RoleAssignment.class))).thenReturn(returnedValue);
+        String jsonString = "{}";
+        // Act + Assert
+        this.mockMvc
+                .perform(post(getRoleAssignmentUri()).contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(content().string(containsString(returnedValue)));
+    }
+
+    @Test
+    void TestPostRoleAssignment_WhenServiceFails_Returns502() throws Exception {
+        // Arrange
+        when(entityService.saveRoleAssignment(Mockito.any(RoleAssignment.class))).thenThrow(RestException.class);
+        String jsonString = "{}";
+
+        // Act + Assert
+        this.mockMvc
+                .perform(post(getRoleAssignmentUri()).contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .andDo(print())
+                .andExpect(status().isBadGateway());
+    }
+
+    private String getRoleAssignmentUri() {
+        return MvcUriComponentsBuilder.fromMethodCall(on(PractitionerController.class)
+                .saveRoleAssignment("987", null)).build().toUriString();
+    }
+
 }

--- a/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/controller/PractitionerControllerTests.java
+++ b/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/controller/PractitionerControllerTests.java
@@ -15,8 +15,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.on;
-import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder;
 import uk.ac.ox.ndph.mts.practitioner_service.model.Practitioner;
 import uk.ac.ox.ndph.mts.practitioner_service.model.RoleAssignment;
 import uk.ac.ox.ndph.mts.practitioner_service.service.EntityService;
@@ -32,10 +30,13 @@ class PractitionerControllerTests {
     @MockBean
     private EntityService entityService;
 
+    private final String practitionerUri = "/practitioner";
+    private final String roleAssignmentUri = "/practitioner/987/roles";
+
     @Test
     void TestPostPractitioner_WhenNoBody_Returns400() throws Exception {
         // Act + Assert
-        this.mockMvc.perform(post(getPractitionerUri()).contentType(MediaType.APPLICATION_JSON))
+        this.mockMvc.perform(post(practitionerUri).contentType(MediaType.APPLICATION_JSON))
                 .andDo(print()).andExpect(status().isBadRequest());
     }
 
@@ -46,7 +47,7 @@ class PractitionerControllerTests {
         String jsonString = "{\"prefix\": \"prefix\", \"givenName\": \"givenName\", \"familyName\": \"familyName\"}";
         // Act + Assert
         this.mockMvc
-                .perform(post(getPractitionerUri()).contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(practitionerUri).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isCreated()).andExpect(content().string(containsString("123")));
     }
 
@@ -57,7 +58,7 @@ class PractitionerControllerTests {
         String jsonString = "{\"givenName\": \"givenName\", \"familyName\": \"familyName\"}";
         // Act + Assert
         this.mockMvc
-                .perform(post(getPractitionerUri()).contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(practitionerUri).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isCreated()).andExpect(content().string(containsString("123")));
     }
 
@@ -69,7 +70,7 @@ class PractitionerControllerTests {
 
         // Act + Assert
         this.mockMvc
-                .perform(post(getPractitionerUri()).contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(practitionerUri).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isBadGateway());
     }
 
@@ -81,14 +82,9 @@ class PractitionerControllerTests {
 
         // Act + Assert
         String error = this.mockMvc
-                .perform(post(getPractitionerUri()).contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(practitionerUri).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isUnprocessableEntity()).andReturn().getResolvedException().getMessage();
         assertThat(error, containsString("prefix"));
-    }
-
-    private String getPractitionerUri() {
-        return MvcUriComponentsBuilder.fromMethodCall(on(PractitionerController.class)
-                .savePractitioner(null)).build().toUriString();
     }
 
 
@@ -97,7 +93,7 @@ class PractitionerControllerTests {
     @Test
     void TestPostRoleAssignment_WhenNoBody_Returns400() throws Exception {
         // Act + Assert
-        this.mockMvc.perform(post(getRoleAssignmentUri()).contentType(MediaType.APPLICATION_JSON))
+        this.mockMvc.perform(post(roleAssignmentUri).contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
@@ -111,7 +107,7 @@ class PractitionerControllerTests {
         String jsonString = "{}";
         // Act + Assert
         this.mockMvc
-                .perform(post(getRoleAssignmentUri()).contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(roleAssignmentUri).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(content().string(containsString(returnedValue)));
@@ -125,14 +121,9 @@ class PractitionerControllerTests {
 
         // Act + Assert
         this.mockMvc
-                .perform(post(getRoleAssignmentUri()).contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(roleAssignmentUri).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print())
                 .andExpect(status().isBadGateway());
-    }
-
-    private String getRoleAssignmentUri() {
-        return MvcUriComponentsBuilder.fromMethodCall(on(PractitionerController.class)
-                .saveRoleAssignment("987", null)).build().toUriString();
     }
 
 }

--- a/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/repository/HapiFhirRepositoryTests.java
+++ b/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/repository/HapiFhirRepositoryTests.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -12,6 +11,8 @@ import java.util.List;
 
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Practitioner;
+import org.hl7.fhir.r4.model.PractitionerRole;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -30,75 +31,143 @@ class HapiFhirRepositoryTests {
     @Captor
     private ArgumentCaptor<Bundle> bundleCaptor;
 
+    private FhirRepository repository;
+
+    @BeforeEach
+    void init() {
+        this.repository = new HapiFhirRepository(fhirContextWrapper);
+    }
+
     @Test
-    void TestHapiRepository_WhenSavePractitioner_SendsBundleWithTrasactionType()
-    {
+    void TestHapiRepository_WhenSavePractitioner_SendsBundleWithTransactionType() {
         // Arrange
         var responseBundle = new Bundle();
-        when(fhirContextWrapper.executeTrasaction(anyString(), any(Bundle.class))).thenReturn(responseBundle);
+        when(fhirContextWrapper.executeTransaction(any(Bundle.class))).thenReturn(responseBundle);
         when(fhirContextWrapper.toListOfResources(any(Bundle.class))).thenReturn(List.of(new Practitioner()));
-        var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
         var practitioner = new Practitioner();
-        
+
         // Act
-        fhirRepository.savePractitioner(practitioner);
+        repository.savePractitioner(practitioner);
 
         // Assert
-        verify(fhirContextWrapper).executeTrasaction(anyString(), bundleCaptor.capture());
+        verify(fhirContextWrapper).executeTransaction(bundleCaptor.capture());
         var value = bundleCaptor.getValue();
         var type = value.getType();
         assertThat(type, equalTo(Bundle.BundleType.TRANSACTION));
     }
 
     @Test
-    void TestHapiRepository_WhenSavePractitioner_ReturnsCorrectId(){
+    void TestHapiRepository_WhenSavePractitioner_ReturnsCorrectId() {
         // Arrange
         var responseBundle = new Bundle();
-        when(fhirContextWrapper.executeTrasaction(anyString(), any(Bundle.class))).thenReturn(responseBundle);
+        when(fhirContextWrapper.executeTransaction(any(Bundle.class))).thenReturn(responseBundle);
         when(fhirContextWrapper.toListOfResources(any(Bundle.class))).thenReturn(List.of(new Practitioner()));
-        var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
         var practitioner = new Practitioner();
         practitioner.setId("123");
-        
+
         // Act
-        var value = fhirRepository.savePractitioner(practitioner);
+        var value = repository.savePractitioner(practitioner);
 
         // Assert
         assertThat(value, equalTo("123"));
     }
-    
+
     @Test
-    void TestHapiRepository_WhenContextWrapperThrowsExpected_ThrowsRestException(){
-        when(fhirContextWrapper.executeTrasaction(anyString(), any(Bundle.class))).thenThrow(new ResourceNotFoundException("error"));
-        var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
+    void TestHapiRepository_WhenContextWrapperThrowsExpected_ThrowsRestException() {
+        when(fhirContextWrapper.executeTransaction(any(Bundle.class))).thenThrow(new ResourceNotFoundException("error"));
         var practitioner = new Practitioner();
-        
+
         // Act + Assert
-        assertThrows(RestException.class, () -> fhirRepository.savePractitioner(practitioner));
+        assertThrows(RestException.class, () -> repository.savePractitioner(practitioner));
     }
-    
+
     @Test
-    void TestHapiRepository_WhenContextReturnsMalformedBundle_ThrowsRestException(){
+    void TestHapiRepository_WhenContextReturnsMalformedBundle_ThrowsRestException() {
         // Arrange
         var responseBundle = new Bundle();
-        when(fhirContextWrapper.executeTrasaction(anyString(), any(Bundle.class))).thenReturn(responseBundle);
+        when(fhirContextWrapper.executeTransaction(any(Bundle.class))).thenReturn(responseBundle);
         when(fhirContextWrapper.toListOfResources(any(Bundle.class))).thenReturn(List.of(new Practitioner(), new Practitioner()));
-        var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
         var practitioner = new Practitioner();
 
         // Act + Assert
-        assertThrows(RestException.class, () -> fhirRepository.savePractitioner(practitioner));
+        assertThrows(RestException.class, () -> repository.savePractitioner(practitioner));
     }
 
     @Test
-    void TestHapiRepository_WhenContextReturnsNull_ThrowsRestException(){
+    void TestHapiRepository_WhenContextReturnsNull_ThrowsRestException() {
         // Arrange
-        when(fhirContextWrapper.executeTrasaction(anyString(), any(Bundle.class))).thenReturn(null);
-
-        var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
+        when(fhirContextWrapper.executeTransaction(any(Bundle.class))).thenReturn(null);
         var practitioner = new Practitioner();
 
         // Act + Assert
-        assertThrows(RestException.class, () -> fhirRepository.savePractitioner(practitioner));
+        assertThrows(RestException.class, () -> repository.savePractitioner(practitioner));
+    }
+
+
+    // PractitionerRole Tests
+
+    @Test
+    void TestSavePractitionerRole_WhenSaveEntity_SendsBundleWithTransactionType() {
+        // Arrange
+        var responseBundle = new Bundle();
+        when(fhirContextWrapper.executeTransaction(any(Bundle.class))).thenReturn(responseBundle);
+        when(fhirContextWrapper.toListOfResources(any(Bundle.class))).thenReturn(List.of(new PractitionerRole()));
+        var entity = new PractitionerRole();
+
+        // Act
+        repository.savePractitionerRole(entity);
+
+        // Assert
+        verify(fhirContextWrapper).executeTransaction(bundleCaptor.capture());
+        var value = bundleCaptor.getValue();
+        var type = value.getType();
+        assertThat(type, equalTo(Bundle.BundleType.TRANSACTION));
+    }
+
+    @Test
+    void TestSavePractitionerRole_WhenSaveEntity_ReturnsCorrectId() {
+        // Arrange
+        var responseBundle = new Bundle();
+        when(fhirContextWrapper.executeTransaction(any(Bundle.class))).thenReturn(responseBundle);
+        var entity = new PractitionerRole();
+        entity.setId("123");
+        when(fhirContextWrapper.toListOfResources(any(Bundle.class))).thenReturn(List.of(entity));
+
+        // Act
+        var value = repository.savePractitionerRole(entity);
+
+        // Assert
+        assertThat(value, equalTo("123"));
+    }
+
+    @Test
+    void TestSavePractitionerRole_WhenExecuteTransactionThrowsException_ThrowsRestException() {
+        when(fhirContextWrapper.executeTransaction(any(Bundle.class))).thenThrow(new ResourceNotFoundException("error"));
+        var entity = new PractitionerRole();
+
+        // Act + Assert
+        assertThrows(RestException.class, () -> repository.savePractitionerRole(entity));
+    }
+
+    @Test
+    void TestSavePractitionerRole_WhenExecuteTransactionReturnsEmptyBundle_ThrowsRestException() {
+        // Arrange
+        var responseBundle = new Bundle();
+        when(fhirContextWrapper.executeTransaction(any(Bundle.class))).thenReturn(responseBundle);
+        when(fhirContextWrapper.toListOfResources(any(Bundle.class))).thenReturn(List.of(new Practitioner(), new Practitioner()));
+        var entity = new PractitionerRole();
+
+        // Act + Assert
+        assertThrows(RestException.class, () -> repository.savePractitionerRole(entity));
+    }
+
+    @Test
+    void TestSavePractitionerRole_WhenExecuteTransactionReturnsNull_ThrowsRestException() {
+        // Arrange
+        when(fhirContextWrapper.executeTransaction(any(Bundle.class))).thenReturn(null);
+        var entity = new PractitionerRole();
+
+        // Act + Assert
+        assertThrows(RestException.class, () -> repository.savePractitionerRole(entity));
     }
 }

--- a/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/service/PractitionerServiceTests.java
+++ b/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/service/PractitionerServiceTests.java
@@ -4,7 +4,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -12,26 +14,38 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import uk.ac.ox.ndph.mts.practitioner_service.exception.InitialisationError;
 import uk.ac.ox.ndph.mts.practitioner_service.exception.ValidationException;
 import uk.ac.ox.ndph.mts.practitioner_service.model.Practitioner;
+import uk.ac.ox.ndph.mts.practitioner_service.model.RoleAssignment;
 import uk.ac.ox.ndph.mts.practitioner_service.model.ValidationResponse;
 import uk.ac.ox.ndph.mts.practitioner_service.repository.EntityStore;
 import uk.ac.ox.ndph.mts.practitioner_service.validation.ModelEntityValidation;
 
 @ExtendWith(MockitoExtension.class)
 class PractitionerServiceTests {
-    
-    @Mock
-    private EntityStore<Practitioner> practitionerStore;
 
     @Mock
-    private ModelEntityValidation<Practitioner> practitionerValidation;
-    
+    private EntityStore<Practitioner> practitionerStore;
+    @Mock
+    private ModelEntityValidation<Practitioner> practitionerValidator;
     @Captor
     ArgumentCaptor<Practitioner> practitionerCaptor;
 
+    @Mock
+    private EntityStore<RoleAssignment> roleAssignmentStore;
+    @Mock
+    private ModelEntityValidation<RoleAssignment> roleAssignmentValidator;
+    @Captor
+    ArgumentCaptor<RoleAssignment> roleAssignmentCaptor;
+
+    private PractitionerService service;
+
+    @BeforeEach
+    void init() {
+        this.service = new PractitionerService(practitionerStore, practitionerValidator,
+                roleAssignmentStore, roleAssignmentValidator);
+    }
 
     @Test
     void TestSavePractitioner_WithPractitioner_ValidatesPractitioner() {
@@ -40,30 +54,28 @@ class PractitionerServiceTests {
         String givenName = "givenName";
         String familyName = "familyName";
         Practitioner practitioner = new Practitioner(prefix, givenName, familyName);
-        var practitionerService = new PractitionerService(practitionerStore, practitionerValidation);
-        when(practitionerValidation.validate(any(Practitioner.class))).thenReturn(new ValidationResponse(true, ""));
+        when(practitionerValidator.validate(any(Practitioner.class))).thenReturn(new ValidationResponse(true, ""));
         when(practitionerStore.saveEntity(any(Practitioner.class))).thenReturn("123");
         //Act
-        practitionerService.savePractitioner(practitioner);
+        service.savePractitioner(practitioner);
 
         //Assert
-        Mockito.verify(practitionerValidation).validate(practitionerCaptor.capture());
+        Mockito.verify(practitionerValidator).validate(practitionerCaptor.capture());
         var value = practitionerCaptor.getValue();
         assertThat(practitioner, equalTo(value));
     }
 
     @Test
-    void TestSavePractitioner_WhenValidPractitioner_SavesToStore(){
+    void TestSavePractitioner_WhenValidPractitioner_SavesToStore() {
         // Arrange
         String prefix = "prefix";
         String givenName = "givenName";
         String familyName = "familyName";
         Practitioner practitioner = new Practitioner(prefix, givenName, familyName);
-        var practitionerService = new PractitionerService(practitionerStore, practitionerValidation);
-        when(practitionerValidation.validate(any(Practitioner.class))).thenReturn(new ValidationResponse(true, ""));
+        when(practitionerValidator.validate(any(Practitioner.class))).thenReturn(new ValidationResponse(true, ""));
         when(practitionerStore.saveEntity(any(Practitioner.class))).thenReturn("123");
         //Act
-        practitionerService.savePractitioner(practitioner);
+        service.savePractitioner(practitioner);
 
         //Assert
         Mockito.verify(practitionerStore).saveEntity(practitionerCaptor.capture());
@@ -72,40 +84,106 @@ class PractitionerServiceTests {
     }
 
     @Test
-    void TestSavePractitioner_WhenInvalidPractitioner_ThrowsValidationException(){
+    void TestSavePractitioner_WhenInvalidPractitioner_ThrowsValidationException() {
         // Arrange
         String prefix = "prefix";
         String givenName = "givenName";
         String familyName = "familyName";
         Practitioner practitioner = new Practitioner(prefix, givenName, familyName);
-        var practitionerService = new PractitionerService(practitionerStore, practitionerValidation);
-        when(practitionerValidation.validate(any(Practitioner.class))).thenReturn(new ValidationResponse(false, "prefix"));
+        when(practitionerValidator.validate(any(Practitioner.class))).thenReturn(new ValidationResponse(false, "prefix"));
         //Act + Assert
-        Assertions.assertThrows(ValidationException.class, () -> practitionerService.savePractitioner(practitioner),
+        Assertions.assertThrows(ValidationException.class, () -> service.savePractitioner(practitioner),
                 "Expecting save to throw validation exception");
     }
 
     @Test
-    void TestSavePractitioner_WhenInvalidPractitioner_DoesntSavesToStore(){
+    void TestSavePractitioner_WhenInvalidPractitioner_DoesntSavesToStore() {
         // Arrange
         String prefix = "prefix";
         String givenName = "givenName";
         String familyName = "familyName";
         Practitioner practitioner = new Practitioner(prefix, givenName, familyName);
-        var practitionerService = new PractitionerService(practitionerStore, practitionerValidation);
-        when(practitionerValidation.validate(any(Practitioner.class))).thenReturn(new ValidationResponse(false, "prefix"));
+        when(practitionerValidator.validate(any(Practitioner.class))).thenReturn(new ValidationResponse(false, "prefix"));
         //Act + Assert
-        Assertions.assertThrows(ValidationException.class, () -> practitionerService.savePractitioner(practitioner),
+        Assertions.assertThrows(ValidationException.class, () -> service.savePractitioner(practitioner),
                 "Expecting save to throw validation exception");
         Mockito.verify(practitionerStore, Mockito.times(0)).saveEntity(any(Practitioner.class));
     }
 
     @Test
-    void TestPractitionerService_WhenNullValues_ThrowsInitialisationError(){
+    void TestPractitionerService_WhenNullValues_ThrowsInitialisationError() {
         // Arrange + Act + Assert
-        Assertions.assertThrows(InitialisationError.class, () -> new PractitionerService(null, practitionerValidation),
+        Assertions.assertThrows(InitialisationError.class, () -> new PractitionerService(null, practitionerValidator
+                        , roleAssignmentStore, roleAssignmentValidator),
                 "null store should throw");
-        Assertions.assertThrows(InitialisationError.class, () -> new PractitionerService(practitionerStore, null),
+        Assertions.assertThrows(InitialisationError.class, () -> new PractitionerService(practitionerStore, null,
+                        roleAssignmentStore, roleAssignmentValidator),
                 "null validation should throw");
+        Assertions.assertThrows(InitialisationError.class, () -> new PractitionerService(practitionerStore,
+                        practitionerValidator, null, roleAssignmentValidator),
+                "null store should throw");
+        Assertions.assertThrows(InitialisationError.class, () -> new PractitionerService(practitionerStore, practitionerValidator,
+                        roleAssignmentStore, null),
+                "null validation should throw");
+    }
+
+
+    // RoleAssignment tests
+
+    @Test
+    void TestSaveRoleAssignment_WhenValidEntity_ValidatesEntity() {
+        // Arrange
+        RoleAssignment entity = new RoleAssignment("practitionerId", "siteId", "roleId");
+        when(roleAssignmentValidator.validate(any(RoleAssignment.class))).thenReturn(new ValidationResponse(true, ""));
+        when(roleAssignmentStore.saveEntity(any(RoleAssignment.class))).thenReturn("123");
+
+        //Act
+        service.saveRoleAssignment(entity);
+
+        //Assert
+        Mockito.verify(roleAssignmentValidator).validate(roleAssignmentCaptor.capture());
+        var entityFromValidator = roleAssignmentCaptor.getValue();
+        assertThat(entity, equalTo(entityFromValidator));
+    }
+
+    @Test
+    void TestSaveRoleAssignment_WhenValidEntity_SavesToStore() {
+        // Arrange
+        RoleAssignment entity = new RoleAssignment("practitionerId", "siteId", "roleId");
+        when(roleAssignmentValidator.validate(any(RoleAssignment.class))).thenReturn(new ValidationResponse(true, ""));
+        when(roleAssignmentStore.saveEntity(any(RoleAssignment.class))).thenReturn("123");
+
+        //Act
+        service.saveRoleAssignment(entity);
+
+        //Assert
+        Mockito.verify(roleAssignmentStore).saveEntity(roleAssignmentCaptor.capture());
+        var entityFromValidator = roleAssignmentCaptor.getValue();
+        assertThat(entity, equalTo(entityFromValidator));
+    }
+
+    @Test
+    void TestSaveRoleAssignment_WhenInvalidEntity_ThrowsValidationException() {
+        // Arrange
+        RoleAssignment entity = new RoleAssignment(null, null, null);
+        when(roleAssignmentValidator.validate(any(RoleAssignment.class))).thenReturn(new ValidationResponse(false,
+                "err"));
+
+        //Act + Assert
+        Assertions.assertThrows(ValidationException.class, () -> service.saveRoleAssignment(entity),
+                "Expecting save to throw validation exception");
+    }
+
+    @Test
+    void TestSaveRoleAssignment_WhenInvalidEntity_DoesntSavesToStore() {
+        // Arrange
+        RoleAssignment entity = new RoleAssignment(null, null, null);
+        when(roleAssignmentValidator.validate(any(RoleAssignment.class))).thenReturn(new ValidationResponse(false,
+                "err"));
+
+        //Act + Assert
+        Assertions.assertThrows(ValidationException.class, () -> service.saveRoleAssignment(entity),
+                "Expecting save to throw validation exception");
+        Mockito.verify(roleAssignmentStore, Mockito.times(0)).saveEntity(any(RoleAssignment.class));
     }
 }

--- a/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/validation/RoleAssignmentValidationTests.java
+++ b/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/validation/RoleAssignmentValidationTests.java
@@ -1,0 +1,52 @@
+package uk.ac.ox.ndph.mts.practitioner_service.validation;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.ac.ox.ndph.mts.practitioner_service.NullableConverter;
+import uk.ac.ox.ndph.mts.practitioner_service.model.RoleAssignment;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+@ExtendWith(MockitoExtension.class)
+class RoleAssignmentValidationTests {
+
+    @ParameterizedTest
+    @CsvSource({",,,practitionerId",
+            ",siteId,roleId,practitionerId",
+            "null,siteId,roleId,practitionerId",
+            "practitionerId,,roleId,siteId",
+            "practitionerId,null,roleId,siteId",
+            "practitionerId,siteId,,roleId",
+            "practitionerId,siteId,null,roleId",
+    })
+    void TestRoleAssignmentValidation_WhenFieldsAreEmptyOrNull_ThrowsValidationException(
+            @ConvertWith(NullableConverter.class) String practitionerId, @ConvertWith(NullableConverter.class) String siteId,
+            @ConvertWith(NullableConverter.class) String roleId, String expectedField) {
+        // Arrange
+        RoleAssignment roleAssignment = new RoleAssignment(practitionerId, siteId, roleId);
+        var validator = new RoleAssignmentValidation();
+
+        // Act + Assert
+        var result = validator.validate(roleAssignment);
+        assertThat(result.isValid(), is(false));
+        assertThat(result.getErrorMessage(), containsString(expectedField));
+    }
+
+    @Test
+    void TestRoleAssignmentValidation_WhenValidPractitioner_ReturnsValidResponse() {
+        // Arrange
+        RoleAssignment roleAssignment = new RoleAssignment("practitionerId", "siteId", "roleId");
+        var validator = new RoleAssignmentValidation();
+
+        // Act
+        var result = validator.validate(roleAssignment);
+        // Assert
+        assertThat(result.isValid(), is(true));
+    }
+
+}


### PR DESCRIPTION
## Description
This is the first PR to support the functionality of assigning roles to users. In a second PR we'll add extended validation to make sure the referenced entities (practitioner, role, site) are indeed exist.

### Changes
- [ARTS-465] - A basic implementation for assigning roles.

### Checklist:

- [x] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-465]: https://ndph-arts.atlassian.net/browse/ARTS-465