### PR TITLE
Publish named images from main branch

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build services
     strategy:
       matrix:
-        service_name: [ "sample-service", "practitioner-service", "trial-config-service" ]
+        service_name: [ "sample-service", "practitioner-service", "trial-config-service", "role-service" ]
     env:
       GHCR: ghcr.io/ndph-arts
     runs-on: ubuntu-latest

--- a/.github/workflows/realease-images-from-main.yml
+++ b/.github/workflows/realease-images-from-main.yml
@@ -15,7 +15,7 @@ jobs:
     name: Retag image & push
     strategy:
       matrix:
-        service_name: [ "sample-service", "practitioner-service", "trial-config-service" ]
+        service_name: [ "sample-service", "practitioner-service", "trial-config-service", "role-service" ]
     env:
       GHCR: ghcr.io/ndph-arts
       # We use 2 tags: latest (every PR merge to main) and nightly (main branch images every night)

--- a/.github/workflows/realease-images-from-main.yml
+++ b/.github/workflows/realease-images-from-main.yml
@@ -18,8 +18,8 @@ jobs:
         service_name: [ "sample-service", "practitioner-service", "trial-config-service", "role-service" ]
     env:
       GHCR: ghcr.io/ndph-arts
-      # We use 2 tags: latest (every PR merge to main) and nightly (main branch images every night)
-      TAG: ${{ github.event_name == 'schedule' && 'nightly' || 'latest' }}
+      # We use 2 tags: main-latest (every PR merge to main) and main-nightly (main branch images every night)
+      TAG: ${{ github.event_name == 'schedule' && 'main-nightly' || 'main-latest' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/realease-images-from-main.yml
+++ b/.github/workflows/realease-images-from-main.yml
@@ -1,0 +1,42 @@
+name: Release named images
+# This action is meant to run on the main branch after a merge to release a named version of the image released
+# before with a hash as a tag.
+
+on:
+  push:
+    # ONLY main branch should be listed below!
+    branches: [ main ]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: '1 1 * * *'
+
+jobs:
+  retag:
+    name: Retag image & push
+    strategy:
+      matrix:
+        service_name: [ "sample-service", "practitioner-service", "trial-config-service" ]
+    env:
+      GHCR: ghcr.io/ndph-arts
+      # We use 2 tags: latest (every PR merge to main) and nightly (main branch images every night)
+      TAG: ${{ github.event_name == 'schedule' && 'nightly' || 'latest' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_LOGIN }}
+      - name: Build & publish runtime image
+        run: |
+          set -o errexit
+          set -o nounset
+
+          FROM_TAG=$GHCR/${{ matrix.service_name }}:${{ github.sha }}
+          TO_TAG=$GHCR/${{ matrix.service_name }}:$TAG
+
+          docker pull $FROM_TAG
+          docker tag $FROM_TAG -t $TO_TAG
+          docker push $TO_TAG


### PR DESCRIPTION
## Description
We need a fixed label to allow repeatable and automatic deployment into fixed environments (like integration, qa, etc.).

### Changes
- [ARTS-469] - publish the pre-built image from the build action when main branch is updated (after the PR is merged; "latest" tag) and every night ("nightly" tag).

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR


[ARTS-469]: https://ndph-arts.atlassian.net/browse/ARTS-469