### PR TITLE
[ARTS-101] Permissions automation api tests

### DIFF
--- a/api-tests/README.md
+++ b/api-tests/README.md
@@ -14,7 +14,7 @@ To run tests locally
 
 # set the env variables and build the docker image locally as per the service under test
 # export BASE_URL, example
-BASE_URL=ttp://localhost:82/roles
+BASE_URL=ttp://localhost:82
 
 # without the html reports
 npm run test 

--- a/api-tests/data/common/utils.js
+++ b/api-tests/data/common/utils.js
@@ -1,0 +1,14 @@
+class utils {
+
+    getRandomString(length) {
+        let result = '';
+        const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        const charactersLength = characters.length;
+        for (let i = 0; i < length; i++) {
+            result += characters.charAt(Math.floor(Math.random() * charactersLength));
+        }
+        return result;
+    }
+}
+
+module.exports = new utils;

--- a/api-tests/data/role-service/permissions.js
+++ b/api-tests/data/role-service/permissions.js
@@ -1,0 +1,14 @@
+const utils = require('../../data/common/utils')
+
+const assignPermission = {
+    "id": utils.getRandomString(7),
+    "permissions": [
+        {
+            "id": "create-person"
+        }
+    ]
+}
+
+module.exports = {
+    assignPermission,
+}

--- a/api-tests/data/role-service/permissions.js
+++ b/api-tests/data/role-service/permissions.js
@@ -9,6 +9,39 @@ const assignPermission = {
     ]
 }
 
+const multiplePermissions = {
+    "id": utils.getRandomString(7),
+    "permissions": [
+        {
+            "id": "create-person"
+        },
+        {
+            "id": "view-person"
+        }
+    ]
+}
+
+const emptyPermission = {
+    "id": utils.getRandomString(7),
+    "permissions": [
+        {
+            "id": ""
+        }
+    ]
+}
+
+const InvalidPermission = {
+    "id": utils.getRandomString(7),
+    "permissions": [
+        {
+            "id": "not-present"
+        }
+    ]
+}
+
 module.exports = {
     assignPermission,
+    multiplePermissions,
+    emptyPermission,
+    InvalidPermission,
 }

--- a/api-tests/data/role-service/roleservice.js
+++ b/api-tests/data/role-service/roleservice.js
@@ -1,5 +1,7 @@
+const utils = require('../../data/common/utils')
+
 const validRole = {
-    "id": getRandomString(7),
+    "id": utils.getRandomString(7),
 }
 
 const emptyString = {
@@ -7,17 +9,7 @@ const emptyString = {
 }
 
 const tooLongId = {
-    "id": getRandomString(256),
-}
-
-function getRandomString(length) {
-    let result = '';
-    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    const charactersLength = characters.length;
-    for (let i = 0; i < length; i++) {
-        result += characters.charAt(Math.floor(Math.random() * charactersLength));
-    }
-    return result;
+    "id": utils.getRandomString(256),
 }
 
 module.exports = {

--- a/api-tests/specs/role-service/permissions.js
+++ b/api-tests/specs/role-service/permissions.js
@@ -31,4 +31,10 @@ describe('As a user I want to set permissions for a role so that I can decide wh
         expect(response.text).to.contain("Permission not-present not found")
     });
 
+    it('User is able to view the created roles', async () => {
+        const response = await baseRequest.get('/roles?page=0&size=2');
+        expect(response.status).to.equal(HttpStatus.OK)
+        expect(response.text).to.contain("id");
+    });
+
 });

--- a/api-tests/specs/role-service/permissions.js
+++ b/api-tests/specs/role-service/permissions.js
@@ -1,0 +1,15 @@
+const requests = require('../../data/role-service/permissions')
+const conf = require('../../config/conf')
+
+beforeEach(function () {
+    baseRequest = request(conf.BASE_URL)
+})
+
+describe('As a user I want to set permissions for a role so that I can decide what functionality users assigned this role will have in the system', function () {
+    it.only('I am able to define the permissions linked to a role', async () => {
+        const response = await baseRequest.post('/roles').send(requests.assignPermission);
+        expect(response.text).to.contain("id")
+        expect(response.status).to.equal(HttpStatus.OK)
+    });
+
+});

--- a/api-tests/specs/role-service/permissions.js
+++ b/api-tests/specs/role-service/permissions.js
@@ -6,10 +6,29 @@ beforeEach(function () {
 })
 
 describe('As a user I want to set permissions for a role so that I can decide what functionality users assigned this role will have in the system', function () {
-    it.only('I am able to define the permissions linked to a role', async () => {
+    it('User is able to assign a permission to a role', async () => {
         const response = await baseRequest.post('/roles').send(requests.assignPermission);
         expect(response.text).to.contain("id")
         expect(response.status).to.equal(HttpStatus.OK)
+    });
+
+
+    it('User is able to assign multiple permissions to a role', async () => {
+        const response = await baseRequest.post('/roles').send(requests.multiplePermissions);
+        expect(response.text).to.contain("id")
+        expect(response.status).to.equal(HttpStatus.OK)
+    });
+
+    it('User gets a bad request error when no permission is assigned to a role', async () => {
+        const response = await baseRequest.post('/roles').send(requests.emptyPermission);
+        expect(response.status).to.equal(HttpStatus.BAD_REQUEST);
+        expect(response.text).to.contain("Permission  not found")
+    });
+
+    it('User gets a bad request error when a non-existing permission is assigned to a role', async () => {
+        const response = await baseRequest.post('/roles').send(requests.InvalidPermission);
+        expect(response.status).to.equal(HttpStatus.BAD_REQUEST);
+        expect(response.text).to.contain("Permission not-present not found")
     });
 
 });


### PR DESCRIPTION
## Description

1. The PR has automation tests written around settings Permissions for a role. The tests check for a valid and negative responses.
2. I have moved the function 'getRandomString' to a utils folder to use globally. 
3. Updated the readme as per the changes done to permissions.
4. Only one acceptance criteria of the story 101 has been added to automation tests, the other one which is tested via a json file configuration (arts-350) hasn't been added to automation as its not possible and also not needed to be tested separately as part of regression. Test ticker, https://ndph-arts.atlassian.net/browse/ARTS-559

### Changes
- [ARTS-101] - Set permissions for a role
- [ARTS-580] - Covers the test approach.
- 
### Checklist:

- [Yes ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [Yes ] I have included a short-meaningful title, description and changes for this PR


[ARTS-101]: https://ndph-arts.atlassian.net/browse/ARTS-101
[ARTS-457]: https://ndph-arts.atlassian.net/browse/ARTS-457

[ARTS-580]: https://ndph-arts.atlassian.net/browse/ARTS-580