### PR TITLE
[ARTS-562] Initialize practitioner service configuration with Spring

### DIFF
--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/configuration/PractitionerConfigurationProvider.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/configuration/PractitionerConfigurationProvider.java
@@ -1,30 +1,26 @@
 package uk.ac.ox.ndph.mts.practitioner_service.configuration;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientException;
 import uk.ac.ox.ndph.mts.practitioner_service.exception.RestException;
+import uk.ac.ox.ndph.mts.practitioner_service.model.PractitionerAttributeConfiguration;
 import uk.ac.ox.ndph.mts.practitioner_service.model.PractitionerConfiguration;
+
+import java.util.List;
 
 /**
  * Provide Practitioner Configuration
  */
 @Component
 public class PractitionerConfigurationProvider {
-
-    @Value("${spring.cloud.config.uri}")
-    private String configURI;
-
-    @Value("${spring.application.name}")
-    private String applicationName;
-
-    @Value("${spring.cloud.config.profile}")
-    private String profile;
-
-    @Value("${spring.cloud.config.label}")
-    private String label;
+    @Autowired
+    PractitionerConfiguration practitionerConfiguration;
 
 
     /**
@@ -32,26 +28,7 @@ public class PractitionerConfigurationProvider {
      * @return PractitionerConfiguration
      */
     public PractitionerConfiguration getConfiguration() {
-
-        PractitionerConfiguration practitionerConfiguration;
-
-        try {
-            practitionerConfiguration = WebClient.create().get()
-                .uri(getRepoURL() + "/" + "practitioner-configuration.json")
-                .accept(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(PractitionerConfiguration.class)
-                .block();
-        } catch (WebClientException wce) {
-            throw new RestException(wce.getMessage());
-        }
-
         return practitionerConfiguration;
 
     }
-
-    private String getRepoURL() {
-        return configURI + "/" + applicationName + "/" + profile + "/" + label;
-    }
-
 }

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/configuration/PractitionerConfigurationProvider.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/configuration/PractitionerConfigurationProvider.java
@@ -1,18 +1,8 @@
 package uk.ac.ox.ndph.mts.practitioner_service.configuration;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.PropertySource;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientException;
-import uk.ac.ox.ndph.mts.practitioner_service.exception.RestException;
-import uk.ac.ox.ndph.mts.practitioner_service.model.PractitionerAttributeConfiguration;
 import uk.ac.ox.ndph.mts.practitioner_service.model.PractitionerConfiguration;
-
-import java.util.List;
 
 /**
  * Provide Practitioner Configuration

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/model/PractitionerAttributeConfiguration.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/model/PractitionerAttributeConfiguration.java
@@ -1,13 +1,18 @@
 package uk.ac.ox.ndph.mts.practitioner_service.model;
 
-import org.springframework.stereotype.Component;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 
-@Component
+
+@Configuration
+@ConfigurationProperties(prefix = "attributes")
+@EnableConfigurationProperties
 public class PractitionerAttributeConfiguration {
 
-    private final String name;
-    private final String displayName;
-    private final String validationRegex;
+    private String name;
+    private String displayName;
+    private String validationRegex;
 
     public PractitionerAttributeConfiguration() {
         this.name = "";
@@ -33,5 +38,17 @@ public class PractitionerAttributeConfiguration {
 
     public String getValidationRegex() {
         return validationRegex;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public void setValidationRegex(String validationRegex) {
+        this.validationRegex = validationRegex;
     }
 }

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/model/PractitionerConfiguration.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/model/PractitionerConfiguration.java
@@ -1,22 +1,21 @@
 package uk.ac.ox.ndph.mts.practitioner_service.model;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-@Component
+@Configuration
+@ConfigurationProperties(prefix = "config")
+@EnableConfigurationProperties
 public class PractitionerConfiguration {
 
-    @Value("${name}")
     private String name;
-
-    @Value("${displayName}")
     private String displayName;
-
-    private final List<PractitionerAttributeConfiguration> attributes;
+    private List<PractitionerAttributeConfiguration> attributes;
 
     public PractitionerConfiguration() {
         this.name = "";
@@ -42,5 +41,17 @@ public class PractitionerConfiguration {
 
     public String getDisplayName() {
         return displayName;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public void setAttributes(List<PractitionerAttributeConfiguration> attributes) {
+        this.attributes = attributes;
     }
 }

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/model/PractitionerConfiguration.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/model/PractitionerConfiguration.java
@@ -1,5 +1,6 @@
 package uk.ac.ox.ndph.mts.practitioner_service.model;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
@@ -9,8 +10,11 @@ import java.util.List;
 @Component
 public class PractitionerConfiguration {
 
-    private final String name;
-    private final String displayName;
+    @Value("${name}")
+    private String name;
+
+    @Value("${displayName}")
+    private String displayName;
 
     private final List<PractitionerAttributeConfiguration> attributes;
 


### PR DESCRIPTION
## Description
- Refactoring of fetching the practitioner configuration file from spring config with spring annotation instead with an http request.
- What allowed us to make the refactor is changing the configuration file from json to yml, essentially making it a property file, which is supported natively by spring cloud config) . [Will be updated in the second repo. ](https://github.com/NDPH-ARTS/mts-trial-deployment-config/pull/35)
### Changes
- [ARTS-562] - Refactor practitioner service configuration fetching

### Checklist:

- [x] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-562]: https://ndph-arts.atlassian.net/browse/ARTS-562