### PR TITLE
[ARTS-589] Add a docker step to enable caching maven dependencies as a layer

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -59,7 +59,7 @@ jobs:
           docker push $TO_TAG
 
   test:
-    name: Test
+    name: API Integration Tests
     if: github.event_name == 'pull_request'
     needs: build
     runs-on: ubuntu-latest

--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -14,6 +14,9 @@ COPY ./role-service/pom.xml ./role-service/pom.xml
 COPY ./site-service/pom.xml ./site-service/pom.xml
 COPY ./init-service/pom.xml ./init-service/pom.xml
 
+# cache most dependencies as a layer to be used in other builds while POMs don't change
+RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 

--- a/init-service/Dockerfile
+++ b/init-service/Dockerfile
@@ -14,6 +14,9 @@ COPY ./sample-service/pom.xml ./sample-service/pom.xml
 COPY ./site-service/pom.xml ./site-service/pom.xml
 COPY ./config-server/pom.xml ./config-server/pom.xml
 
+# cache most dependencies as a layer to be used in other builds while POMs don't change
+RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 

--- a/practitioner-service/Dockerfile
+++ b/practitioner-service/Dockerfile
@@ -14,6 +14,9 @@ COPY ./role-service/pom.xml ./role-service/pom.xml
 COPY ./init-service/pom.xml ./init-service/pom.xml
 COPY ./site-service/pom.xml ./site-service/pom.xml
 
+# cache most dependencies as a layer to be used in other builds while POMs don't change
+RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 

--- a/role-service/Dockerfile
+++ b/role-service/Dockerfile
@@ -14,6 +14,9 @@ COPY ./config-server/pom.xml ./config-server/pom.xml
 COPY ./init-service/pom.xml ./init-service/pom.xml
 COPY ./site-service/pom.xml ./site-service/pom.xml
 
+# cache most dependencies as a layer to be used in other builds while POMs don't change
+RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 

--- a/sample-service/Dockerfile
+++ b/sample-service/Dockerfile
@@ -14,6 +14,9 @@ COPY ./role-service/pom.xml ./role-service/pom.xml
 COPY ./init-service/pom.xml ./init-service/pom.xml
 COPY ./site-service/pom.xml ./site-service/pom.xml
 
+# cache most dependencies as a layer to be used in other builds while POMs don't change
+RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 

--- a/site-service/Dockerfile
+++ b/site-service/Dockerfile
@@ -14,6 +14,9 @@ COPY ./config-server/pom.xml ./config-server/pom.xml
 COPY ./role-service/pom.xml ./role-service/pom.xml
 COPY ./init-service/pom.xml ./init-service/pom.xml
 
+# cache most dependencies as a layer to be used in other builds while POMs don't change
+RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 

--- a/trial-config-service/Dockerfile
+++ b/trial-config-service/Dockerfile
@@ -14,6 +14,9 @@ COPY ./role-service/pom.xml ./role-service/pom.xml
 COPY ./init-service/pom.xml ./init-service/pom.xml
 COPY ./site-service/pom.xml ./site-service/pom.xml
 
+# cache most dependencies as a layer to be used in other builds while POMs don't change
+RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 


### PR DESCRIPTION
## Description
Docker builds take a long time since **every** container downloads its own maven dependencies on **every** build. This PR add a step in the docker files to enable the dependencies to be cached as a separate layer and be reused between build actions on the same machine.

### Changes
- [ARTS-589] cache maven deps as docker layer

### Checklist:

- [x] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-589]: https://ndph-arts.atlassian.net/browse/ARTS-589