### PR TITLE
[ARTS-404] Get sites from site service

### DIFF
--- a/site-service/README.md
+++ b/site-service/README.md
@@ -27,7 +27,7 @@ Creates a new site entity.
 
 #### Success Response
 
-**Condition** : If site was created succesfully in the FHIR store.
+**Condition** : If site was created successfully in the FHIR store.
 
 **Code** : `201 CREATED`
 
@@ -73,6 +73,55 @@ Creates a new site entity.
     "error": "Fhir store connection failed with error..."
 }
 ```
+
+**Method** : `GET`
+
+**Parameters**: none
+
+#### Success Response
+
+**Condition** : If at least one site exists in the FHIR store
+
+**Code** : `200 OK`
+
+**Content example**
+
+```json
+[
+    {
+        "name": "CCO",
+        "alias": "CCO",
+        "parentSiteId": null,
+        "siteId":  "01ced0b1-a6e6-4408-9701-0ced2fff9a26"
+    }, 
+    {
+        "name": "UK",
+        "alias": "UK RCC",
+        "parentSiteId": "01ced0b1-a6e6-4408-9701-0ced2fff9a26",
+        "siteId": "02dfe1c2-a6e6-4408-9701-0ced2000ab37"
+    } 
+]
+```
+
+#### Or
+
+**Condition** : If FHIR store is unavailable.
+
+**Code** : `502 Bad Gateway`
+
+**Content** :
+
+#### Or
+
+**Condition** : If no sites.
+
+**Code** : `501 Not Implemented`
+
+**Content** :
+
+**Notes** : Means there are no sites in the store, so the invariant condition that there is always a root site
+is violated - but this may be a temporary condition so client may retry later.
+
 ___
 
 ## Service Dependecies

--- a/site-service/pom.xml
+++ b/site-service/pom.xml
@@ -61,6 +61,16 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-boot-starter</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger-ui</artifactId>
+            <version>3.0.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/configuration/WebConfig.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/configuration/WebConfig.java
@@ -1,0 +1,24 @@
+package uk.ac.ox.ndph.mts.site_service.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+/**
+ * This configuration enables the Swagger UI at /swagger-ui/
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2).select().apis(
+                RequestHandlerSelectors.basePackage("uk.ac.ox.ndph.mts.site_service.controller"))
+                .paths(PathSelectors.any()).build();
+    }
+
+}

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/controller/SiteController.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/controller/SiteController.java
@@ -49,7 +49,7 @@ public class SiteController {
      */
     @GetMapping
     public ResponseEntity<List<Site>> sites() {
-        return ResponseEntity.status(HttpStatus.OK).body(siteService.getSites());
+        return ResponseEntity.status(HttpStatus.OK).body(siteService.findSites());
     }
 
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/controller/SiteController.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/controller/SiteController.java
@@ -3,6 +3,7 @@ package uk.ac.ox.ndph.mts.site_service.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +11,8 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ox.ndph.mts.site_service.model.Response;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
 import uk.ac.ox.ndph.mts.site_service.service.SiteService;
+
+import java.util.List;
 
 /**
  * Controller for site endpoint of site-service
@@ -39,4 +42,14 @@ public class SiteController {
         String siteId = siteService.save(site);
         return ResponseEntity.status(HttpStatus.CREATED).body(new Response(siteId));
     }
+
+    /**
+     * Get complete sites list
+     * @return ResponseEntity
+     */
+    @GetMapping
+    public ResponseEntity<List<Site>> sites() {
+        return ResponseEntity.status(HttpStatus.OK).body(siteService.getSites());
+    }
+
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/OrganizationConverter.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/OrganizationConverter.java
@@ -6,6 +6,8 @@ import org.hl7.fhir.r4.model.Reference;
 import org.springframework.stereotype.Component;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
 
+import static uk.ac.ox.ndph.mts.site_service.converter.SiteConverter.ORG_PREFIX;
+
 /**
  */
 @Component
@@ -34,7 +36,7 @@ public class OrganizationConverter implements EntityConverter<Site, org.hl7.fhir
             // TODO: Check if the Parent Organization already exists.
 
             // Set the Parent Organization if and only if it exists.
-            fhirOrganization.setPartOf(new Reference("Organization/" + site.getParentSiteId()));
+            fhirOrganization.setPartOf(new Reference(ORG_PREFIX + site.getParentSiteId()));
         }
     }
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/OrganizationConverter.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/OrganizationConverter.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Component;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
 
 /**
- * Implement an EntityConverter for Site
  */
 @Component
 public class OrganizationConverter implements EntityConverter<Site, org.hl7.fhir.r4.model.Organization> {

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/OrganizationConverter.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/OrganizationConverter.java
@@ -6,8 +6,6 @@ import org.hl7.fhir.r4.model.Reference;
 import org.springframework.stereotype.Component;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
 
-import static uk.ac.ox.ndph.mts.site_service.converter.SiteConverter.ORG_PREFIX;
-
 /**
  */
 @Component
@@ -36,7 +34,8 @@ public class OrganizationConverter implements EntityConverter<Site, org.hl7.fhir
             // TODO: Check if the Parent Organization already exists.
 
             // Set the Parent Organization if and only if it exists.
-            fhirOrganization.setPartOf(new Reference(ORG_PREFIX + site.getParentSiteId()));
+            fhirOrganization.setPartOf(new Reference("Organization/" + site.getParentSiteId()));
         }
     }
+
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/OrganizationConverter.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/OrganizationConverter.java
@@ -6,8 +6,6 @@ import org.hl7.fhir.r4.model.Reference;
 import org.springframework.stereotype.Component;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
 
-/**
- */
 @Component
 public class OrganizationConverter implements EntityConverter<Site, org.hl7.fhir.r4.model.Organization> {
 

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverter.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverter.java
@@ -1,6 +1,5 @@
 package uk.ac.ox.ndph.mts.site_service.converter;
 
-import org.apache.commons.lang.StringUtils;
 import org.hl7.fhir.r4.model.Organization;
 import org.springframework.stereotype.Component;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
@@ -11,11 +10,9 @@ import uk.ac.ox.ndph.mts.site_service.model.Site;
 @Component
 public class SiteConverter implements EntityConverter<org.hl7.fhir.r4.model.Organization, Site> {
 
-    static final String ORG_PREFIX = "Organization/";
-
     @Override
     public Site convert(final Organization org) {
-        final String siteId = org.getId(); // is this the correct ID?
+        final String siteId = org.getIdElement().getIdPart();
         final String name = org.getName();
         final String alias = (org.getAlias().isEmpty()) ? null : org.getAlias().get(0).getValueAsString();
         final String parentSiteId = findParentSiteId(org);
@@ -24,10 +21,10 @@ public class SiteConverter implements EntityConverter<org.hl7.fhir.r4.model.Orga
 
     private String findParentSiteId(final Organization org) {
         if (org.hasPartOf()) {
-            return StringUtils.remove(org.getPartOf().getReference(), ORG_PREFIX);
+            return org.getPartOf().getReferenceElement().getIdPart();
+        } else {
+            return null;
         }
-        // default
-        return null;
     }
 
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverter.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverter.java
@@ -1,0 +1,22 @@
+package uk.ac.ox.ndph.mts.site_service.converter;
+
+import org.hl7.fhir.r4.model.Organization;
+import org.springframework.stereotype.Component;
+import uk.ac.ox.ndph.mts.site_service.model.Site;
+
+/**
+ * Implement an EntityConverter for Site. Reverse of {@link OrganizationConverter}.
+ */
+@Component
+public class SiteConverter implements EntityConverter<org.hl7.fhir.r4.model.Organization, Site> {
+
+    @Override
+    public Site convert(final Organization org) {
+        final String siteId = org.getId(); // is this the correct ID?
+        final String name = org.getName();
+        final String alias = (org.getAlias().isEmpty()) ? null : org.getAlias().get(0).getValueAsString();
+        final String parentSiteId = (org.getPartOf() == null) ? null : org.getPartOf().getId();
+        return Site.withIdNameAliasAndParent(siteId, name, alias, parentSiteId);
+    }
+
+}

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverter.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverter.java
@@ -1,5 +1,6 @@
 package uk.ac.ox.ndph.mts.site_service.converter;
 
+import org.apache.commons.lang.StringUtils;
 import org.hl7.fhir.r4.model.Organization;
 import org.springframework.stereotype.Component;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
@@ -10,13 +11,23 @@ import uk.ac.ox.ndph.mts.site_service.model.Site;
 @Component
 public class SiteConverter implements EntityConverter<org.hl7.fhir.r4.model.Organization, Site> {
 
+    static final String ORG_PREFIX = "Organization/";
+
     @Override
     public Site convert(final Organization org) {
         final String siteId = org.getId(); // is this the correct ID?
         final String name = org.getName();
         final String alias = (org.getAlias().isEmpty()) ? null : org.getAlias().get(0).getValueAsString();
-        final String parentSiteId = (org.getPartOf() == null) ? null : org.getPartOf().getId();
+        final String parentSiteId = findParentSiteId(org);
         return Site.withIdNameAliasAndParent(siteId, name, alias, parentSiteId);
+    }
+
+    private String findParentSiteId(final Organization org) {
+        if (org.hasPartOf()) {
+            return StringUtils.remove(org.getPartOf().getReference(), ORG_PREFIX);
+        }
+        // default
+        return null;
     }
 
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverter.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverter.java
@@ -12,11 +12,12 @@ public class SiteConverter implements EntityConverter<org.hl7.fhir.r4.model.Orga
 
     @Override
     public Site convert(final Organization org) {
-        final String siteId = org.getIdElement().getIdPart();
-        final String name = org.getName();
-        final String alias = (org.getAlias().isEmpty()) ? null : org.getAlias().get(0).getValueAsString();
-        final String parentSiteId = findParentSiteId(org);
-        return Site.withIdNameAliasAndParent(siteId, name, alias, parentSiteId);
+        return new Site(
+                org.getIdElement().getIdPart(),
+                org.getName(),
+                (org.getAlias().isEmpty()) ? null : org.getAlias().get(0).getValueAsString(),
+                findParentSiteId(org)
+        );
     }
 
     private String findParentSiteId(final Organization org) {

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/exception/InvariantException.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/exception/InvariantException.java
@@ -1,0 +1,25 @@
+package uk.ac.ox.ndph.mts.site_service.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Thrown when an invariant is violated retrieving from the store (not from the client end - that would
+ * be a {@link ValidationException}.
+ */
+@ResponseStatus(value = HttpStatus.NOT_IMPLEMENTED)
+public class InvariantException extends RuntimeException {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 6563074749881235497L;
+
+    /**
+     *
+     * @param message The exception message
+     */
+    public InvariantException(String message) {
+        super(message);
+    }
+}

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/Site.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/Site.java
@@ -1,5 +1,7 @@
 package uk.ac.ox.ndph.mts.site_service.model;
 
+import java.util.Objects;
+
 /**
  * Site Model
  */
@@ -24,7 +26,7 @@ public class Site {
     }
 
     /**
-     * Site Constructor with two parameters
+     * Site Constructor with name alias and parent
      *
      * @param name the Site name
      * @param alias the Site alias
@@ -37,8 +39,26 @@ public class Site {
         this.parentSiteId = parentSiteId;
     }
 
+
+    /**
+     * Site factory with name alias parent and ID
+     * make this a named factory to avoid mixing up site ID with parent site ID
+     * @param siteId site ID (never null)
+     * @param name the Site name
+     * @param alias the Site alias
+     * @param parentSiteId the Site parentSiteId
+     *
+     */
+    public static Site withIdNameAliasAndParent(final String siteId, String name, String alias, String parentSiteId) {
+        final Site site = new Site(name, alias, parentSiteId);
+        Objects.requireNonNull(siteId);
+        site.setSiteId(siteId);
+        return site;
+    }
+
     private String name;
     private String alias;
+    private String siteId;
     private String parentSiteId;
 
     /**
@@ -92,5 +112,13 @@ public class Site {
      */
     public void setParentSiteId(String parentSiteId) {
         this.parentSiteId = parentSiteId;
+    }
+
+    public String getSiteId() {
+        return siteId;
+    }
+
+    public void setSiteId(String siteId) {
+        this.siteId = siteId;
     }
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/Site.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/Site.java
@@ -1,7 +1,5 @@
 package uk.ac.ox.ndph.mts.site_service.model;
 
-import java.util.Objects;
-
 /**
  * Site Model
  */

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/Site.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/Site.java
@@ -41,19 +41,16 @@ public class Site {
 
 
     /**
-     * Site factory with name alias parent and ID
-     * make this a named factory to avoid mixing up site ID with parent site ID
-     * @param siteId site ID (never null)
+     * Site Constructor with siteId name alias and parent
+     * @param siteId site ID
      * @param name the Site name
      * @param alias the Site alias
      * @param parentSiteId the Site parentSiteId
      *
      */
-    public static Site withIdNameAliasAndParent(final String siteId, String name, String alias, String parentSiteId) {
-        final Site site = new Site(name, alias, parentSiteId);
-        Objects.requireNonNull(siteId);
-        site.setSiteId(siteId);
-        return site;
+    public Site(final String siteId, String name, String alias, String parentSiteId) {
+        this(name, alias, parentSiteId);
+        this.siteId = siteId;
     }
 
     private String name;

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/EntityStore.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/EntityStore.java
@@ -1,5 +1,7 @@
 package uk.ac.ox.ndph.mts.site_service.repository;
 
+import java.util.List;
+
 /**
  * Interface for a store of a data model entity
  */
@@ -11,4 +13,6 @@ public interface EntityStore<T> {
      * @return the entity stored id.
      */
     String saveEntity(T entity);
+
+    List<T> geAllEntities();
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/EntityStore.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/EntityStore.java
@@ -14,5 +14,5 @@ public interface EntityStore<T> {
      */
     String saveEntity(T entity);
 
-    List<T> geAllEntities();
+    List<T> findAll();
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
@@ -64,11 +64,12 @@ public class FhirContextWrapper {
     /**
      * Return a search instance which can be configured and executed, returning a single type of resource
      * @param uri FHIR endpoint URI
+     * @param resourceClass class of resource to return in bundle
      */
-    public IQuery<Bundle> search(final String uri, final String resourceName) {
+    public IQuery<Bundle> search(final String uri, final Class<? extends IBaseResource> resourceClass) {
         return fhirContext.newRestfulGenericClient(uri)
                 .search()
-                .forResource(resourceName)
+                .forResource(resourceClass)
                 .returnBundle(Bundle.class);
     }
 

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
@@ -3,6 +3,7 @@ package uk.ac.ox.ndph.mts.site_service.repository;
 import java.util.ArrayList;
 import java.util.List;
 
+import ca.uhn.fhir.rest.gclient.IQuery;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.springframework.stereotype.Component;
@@ -50,8 +51,25 @@ public class FhirContextWrapper {
      * @return the list of resources in the bundle
      */
     public List<IBaseResource> toListOfResources(Bundle bundle) {
-        List<IBaseResource> resp = new ArrayList<>();
-        resp.addAll(BundleUtil.toListOfResources(fhirContext, bundle));
-        return resp;
+        return new ArrayList<>(BundleUtil.toListOfResources(fhirContext, bundle));
     }
+
+    /**
+     * Typed version of to list of resources
+     */
+    public <T extends IBaseResource> List<T> toListOfResourcesOfType(Bundle bundle, Class<T> resourceClass) {
+        return new ArrayList<>(BundleUtil.toListOfResourcesOfType(this.fhirContext, bundle, resourceClass));
+    }
+
+    /**
+     * Return a search instance which can be configured and executed, returning a single type of resource
+     * @param uri FHIR endpoint URI
+     */
+    public IQuery<Bundle> search(final String uri, final String resourceName) {
+        return fhirContext.newRestfulGenericClient(uri)
+                .search()
+                .forResource(resourceName)
+                .returnBundle(Bundle.class);
+    }
+
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
@@ -40,7 +40,7 @@ public class FhirContextWrapper {
      * @param input the Bundle to save
      * @return the returned Bundle object from FHIR endpoint
      */
-    public Bundle executeTrasaction(String uri, Bundle input) {
+    public Bundle executeTransaction(String uri, Bundle input) {
         return fhirContext.newRestfulGenericClient(uri).transaction()
                     .withBundle(input).execute();
     }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirRepo.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirRepo.java
@@ -7,7 +7,8 @@ public enum FhirRepo {
     SAVE_REQUEST("request to fhir: %s"),
     SAVE_RESPONSE("response from fhir: %s"),
     UPDATE_ERROR("error while updating fhir store"),
-    BAD_RESPONSE_SIZE("bad response size from FHIR: %d");
+    BAD_RESPONSE_SIZE("bad response size from FHIR: %d"),
+    SEARCH_ERROR("error while searching for resource: %s");
 
     private String message;
  

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirRepository.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirRepository.java
@@ -30,6 +30,6 @@ public interface FhirRepository {
      * not {uk.ac.ox.ndph.mts.site_service.model.Site}s - caller must filter.
      * @return all organization instances in the store, might be empty, not null
      */
-    Collection<Organization> getOrganizations();
+    Collection<Organization> findOrganizations();
 
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirRepository.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirRepository.java
@@ -3,6 +3,8 @@ package uk.ac.ox.ndph.mts.site_service.repository;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.ResearchStudy;
 
+import java.util.Collection;
+
 /**
  * Interface for a FHIR entity repository
  */
@@ -22,4 +24,12 @@ public interface FhirRepository {
      * @return ResearchStudy
      */
     String saveResearchStudy(ResearchStudy researchStudy);
+
+    /**
+     * Return the list of all organizations. Note this may include organizations that are
+     * not {uk.ac.ox.ndph.mts.site_service.model.Site}s - caller must filter.
+     * @return all organization instances in the store, might be empty, not null
+     */
+    Collection<Organization> getOrganizations();
+
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepository.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepository.java
@@ -41,16 +41,13 @@ public class HapiFhirRepository implements FhirRepository {
      */
     public Collection<Organization> getOrganizations() {
         try {
-            // note no where clause here - just gets all the orgs;
-            // would like to filter on sites (by the site type extension?)
+            // TODO: filter organizations by the extension element that identifies them as sites
             final Bundle responseBundle = fhirContextWrapper
                     .search(fhirUri, ORGANIZATION_ENTITY_NAME)
                     .execute();
             return fhirContextWrapper.toListOfResourcesOfType(responseBundle, Organization.class);
         } catch (BaseServerResponseException e) {
-            logger.warn(String.format(
-                    FhirRepo.SEARCH_ERROR.message(), ORGANIZATION_ENTITY_NAME), e);
-            throw new RestException(e.getMessage(), e);
+            throw new RestException(String.format(FhirRepo.SEARCH_ERROR.message(), e.getMessage()), e);
         }
     }
 
@@ -59,13 +56,12 @@ public class HapiFhirRepository implements FhirRepository {
      * @return id of the saved organization
      */
     public String saveOrganization(Organization organization) {
-        // Log the request
         logger.info(FhirRepo.SAVE_REQUEST.message(),
                 fhirContextWrapper.prettyPrint(organization));
 
         Bundle responseBundle;
         try {
-            responseBundle = fhirContextWrapper.executeTrasaction(fhirUri, 
+            responseBundle = fhirContextWrapper.executeTransaction(fhirUri,
                 bundle(organization, ORGANIZATION_ENTITY_NAME));
         } catch (BaseServerResponseException e) {
             logger.warn(FhirRepo.UPDATE_ERROR.message(), e);
@@ -92,7 +88,7 @@ public class HapiFhirRepository implements FhirRepository {
 
         Bundle responseBundle;
         try {
-            responseBundle = fhirContextWrapper.executeTrasaction(fhirUri,
+            responseBundle = fhirContextWrapper.executeTransaction(fhirUri,
                     bundle(researchStudy, RESEARCHSTUDY_ENTITY_NAME));
         } catch (BaseServerResponseException e) {
             logger.warn(FhirRepo.UPDATE_ERROR.message(), e);

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepository.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepository.java
@@ -43,7 +43,7 @@ public class HapiFhirRepository implements FhirRepository {
         try {
             // TODO: filter organizations by the extension element that identifies them as sites
             final Bundle responseBundle = fhirContextWrapper
-                    .search(fhirUri, ORGANIZATION_ENTITY_NAME)
+                    .search(fhirUri, Organization.class)
                     .execute();
             return fhirContextWrapper.toListOfResourcesOfType(responseBundle, Organization.class);
         } catch (BaseServerResponseException e) {

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepository.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepository.java
@@ -1,15 +1,15 @@
 package uk.ac.ox.ndph.mts.site_service.repository;
 
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.ResearchStudy;
+import org.hl7.fhir.r4.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.hl7.fhir.r4.model.Resource;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import uk.ac.ox.ndph.mts.site_service.exception.RestException;
 
 import java.util.Collection;
@@ -39,7 +39,7 @@ public class HapiFhirRepository implements FhirRepository {
      * not {uk.ac.ox.ndph.mts.site_service.model.Site}s - caller must filter.
      * @return all organization instances in the store, might be empty, not null
      */
-    public Collection<Organization> getOrganizations() {
+    public Collection<Organization> findOrganizations() {
         try {
             // TODO: filter organizations by the extension element that identifies them as sites
             final Bundle responseBundle = fhirContextWrapper

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/SiteStore.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/SiteStore.java
@@ -76,7 +76,7 @@ public class SiteStore implements EntityStore<Site> {
      */
     @Override
     public List<Site> findAll() {
-        return this.repository.getOrganizations()
+        return this.repository.findOrganizations()
                 .stream()
                 .map(fromOrgConverter::convert)
                 .collect(Collectors.toList());

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/SiteStore.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/SiteStore.java
@@ -75,7 +75,7 @@ public class SiteStore implements EntityStore<Site> {
      * @return list of site entities
      */
     @Override
-    public List<Site> geAllEntities() {
+    public List<Site> findAll() {
         return this.repository.getOrganizations()
                 .stream()
                 .map(fromOrgConverter::convert)

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/service/Services.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/service/Services.java
@@ -4,7 +4,8 @@ package uk.ac.ox.ndph.mts.site_service.service;
  * String constants
  */
 public enum Services {
-    STARTUP("Loaded site service required dependencies");
+    STARTUP("Loaded site service required dependencies"),
+    NO_ROOT_SITE("No root site found");
 
     private String message;
  

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/service/SiteService.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/service/SiteService.java
@@ -21,5 +21,5 @@ public interface SiteService {
      * Get all current sites
      * @return list of sites, should never be empty (always have a root node)
      */
-    List<Site> getSites();
+    List<Site> findSites();
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/service/SiteService.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/service/SiteService.java
@@ -2,6 +2,8 @@ package uk.ac.ox.ndph.mts.site_service.service;
 
 import uk.ac.ox.ndph.mts.site_service.model.Site;
 
+import java.util.List;
+
 /**
  * Interface for validating and saving an entity
  */
@@ -14,4 +16,10 @@ public interface SiteService {
      * @return the id of the created entity.
      */
     String save(Site site);
+
+    /**
+     * Get all current sites
+     * @return list of sites, should never be empty (always have a root node)
+     */
+    List<Site> getSites();
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/service/SiteServiceImpl.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/service/SiteServiceImpl.java
@@ -4,12 +4,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
+import org.springframework.web.bind.annotation.GetMapping;
 import uk.ac.ox.ndph.mts.site_service.exception.InitialisationError;
+import uk.ac.ox.ndph.mts.site_service.exception.InvariantException;
 import uk.ac.ox.ndph.mts.site_service.exception.ValidationException;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
 import uk.ac.ox.ndph.mts.site_service.repository.EntityStore;
 import uk.ac.ox.ndph.mts.site_service.validation.ModelEntityValidation;
+
+import java.util.List;
 
 /**
  * Implement an SiteServiceInterface interface.
@@ -56,4 +59,19 @@ public class SiteServiceImpl implements SiteService {
         }
         return siteStore.saveEntity(site);
     }
+
+    /**
+     * Get complete sites list
+     * @return list of sites, never empty
+     * @throws InvariantException if the list from the store is empty
+     */
+    @GetMapping
+    public List<Site> getSites() {
+        final List<Site> sites = this.siteStore.geAllEntities();
+        if (sites.isEmpty()) {
+            throw new InvariantException(Services.NO_ROOT_SITE.message());
+        }
+        return sites;
+    }
+
 }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/service/SiteServiceImpl.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/service/SiteServiceImpl.java
@@ -61,13 +61,15 @@ public class SiteServiceImpl implements SiteService {
     }
 
     /**
-     * Get complete sites list
+     * Get complete sites list.  Note the list should never be empty if the trial has been initialized, and
+     * this method should not be called if the trial has not been initialized. So throws an exception if the
+     * store returns an empty sites list.
      * @return list of sites, never empty
      * @throws InvariantException if the list from the store is empty
      */
     @GetMapping
-    public List<Site> getSites() {
-        final List<Site> sites = this.siteStore.geAllEntities();
+    public List<Site> findSites() {
+        final List<Site> sites = this.siteStore.findAll();
         if (sites.isEmpty()) {
             throw new InvariantException(Services.NO_ROOT_SITE.message());
         }

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/SiteServiceImplIntegrationTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/SiteServiceImplIntegrationTests.java
@@ -30,6 +30,8 @@ import java.util.List;
 @ActiveProfiles("test-all-required")
 @AutoConfigureMockMvc
 class SiteServiceImplIntegrationTests {
+    
+    public static final String SITES_ROUTE = "/sites";
 
     @Autowired
     private MockMvc mockMvc;
@@ -46,7 +48,7 @@ class SiteServiceImplIntegrationTests {
         String jsonString = "{\"name\": \"name\", \"alias\": \"alias\"}";
         // Act + Assert
         this.mockMvc
-                .perform(post("/sites").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isCreated()).andExpect(content().string(containsString("123")));
     }
 
@@ -58,7 +60,7 @@ class SiteServiceImplIntegrationTests {
         String jsonString = "{\"name\": \"\", \"alias\": \"alias\"}";
         // Act + Assert
         var error = this.mockMvc
-                .perform(post("/sites").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isUnprocessableEntity()).andReturn().getResolvedException().getMessage();
         assertThat(error, containsString("Name"));
     }
@@ -71,7 +73,7 @@ class SiteServiceImplIntegrationTests {
         String jsonString = "{\"name\": \"name\", \"alias\": \"alias\"}";
         // Act + Assert
         var error = this.mockMvc
-                .perform(post("/sites").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isBadGateway()).andReturn().getResolvedException().getMessage();
         assertThat(error, containsString("test error"));
     }
@@ -85,7 +87,7 @@ class SiteServiceImplIntegrationTests {
         String jsonString = "{\"name\": \"name\", \"alias\": \"alias\", \"parentSiteId\": \"parentSiteId\"}";
         // Act + Assert
         this.mockMvc
-                .perform(post("/sites").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isCreated()).andExpect(content().string(containsString("123")));
     }
 
@@ -99,7 +101,7 @@ class SiteServiceImplIntegrationTests {
         when(repository.getOrganizations()).thenReturn(List.of(org));
         // Act + Assert
         this.mockMvc
-                .perform(get("/sites").contentType(MediaType.APPLICATION_JSON))
+                .perform(get(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andExpect(content().string(containsString("\"this-is-my-id\"")));
     }
 
@@ -110,7 +112,7 @@ class SiteServiceImplIntegrationTests {
         when(repository.getOrganizations()).thenReturn(Collections.emptyList());
         // Act + Assert
         final var message = this.mockMvc
-                .perform(get("/sites").contentType(MediaType.APPLICATION_JSON))
+                .perform(get(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotImplemented()).andReturn().getResolvedException().getMessage();
         assertThat(message, containsString("No root site"));
     }

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/SiteServiceImplIntegrationTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/SiteServiceImplIntegrationTests.java
@@ -10,21 +10,21 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import static org.hamcrest.Matchers.containsString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import uk.ac.ox.ndph.mts.site_service.exception.RestException;
 import uk.ac.ox.ndph.mts.site_service.repository.FhirRepository;
 
 import java.util.Collections;
 import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(properties = { "server.error.include-message=always", "spring.main.allow-bean-definition-overriding=true" })
 @ActiveProfiles("test-all-required")
@@ -98,7 +98,7 @@ class SiteServiceImplIntegrationTests {
                 .setName("CCO")
                 .addAlias("Root");
         org.setId("this-is-my-id");
-        when(repository.getOrganizations()).thenReturn(List.of(org));
+        when(repository.findOrganizations()).thenReturn(List.of(org));
         // Act + Assert
         this.mockMvc
                 .perform(get(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON))
@@ -109,7 +109,7 @@ class SiteServiceImplIntegrationTests {
     @Test
     void TestGetSites_WhenNoSites_ReturnsInternalServerError() throws Exception {
         // Arrange
-        when(repository.getOrganizations()).thenReturn(Collections.emptyList());
+        when(repository.findOrganizations()).thenReturn(Collections.emptyList());
         // Act + Assert
         final var message = this.mockMvc
                 .perform(get(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON))

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/SiteServiceImplIntegrationTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/SiteServiceImplIntegrationTests.java
@@ -31,7 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 class SiteServiceImplIntegrationTests {
     
-    public static final String SITES_ROUTE = "/sites";
+    private static final String SITES_ROUTE = "/sites";
 
     @Autowired
     private MockMvc mockMvc;

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/controller/SiteControllerTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/controller/SiteControllerTests.java
@@ -94,7 +94,7 @@ class SiteControllerTests {
     @Test
     void TestGetSite_WhenNoSites_Returns501() throws Exception {
         // Arrange
-        when(siteService.getSites()).thenThrow(new InvariantException("root"));
+        when(siteService.findSites()).thenThrow(new InvariantException("root"));
         // Act + Assert
         final String error = this.mockMvc
                 .perform(get("/sites").contentType(MediaType.APPLICATION_JSON))
@@ -106,7 +106,7 @@ class SiteControllerTests {
     @Test
     void TestGetSite_WhenSites_Returns200AndList() throws Exception {
         // arrange
-        when(siteService.getSites()).thenReturn(Collections.singletonList(new Site("CCO", "Root")));
+        when(siteService.findSites()).thenReturn(Collections.singletonList(new Site("CCO", "Root")));
         // act
         final String result = this.mockMvc
                 .perform(get("/sites").contentType(MediaType.APPLICATION_JSON))
@@ -120,7 +120,7 @@ class SiteControllerTests {
     @Test
     void TestGetSite_WhenFhirDependencyFails_Returns502() throws Exception {
         // Arrange
-        when(siteService.getSites()).thenThrow(RestException.class);
+        when(siteService.findSites()).thenThrow(RestException.class);
         // Act + Assert
         this.mockMvc
                 .perform(get("/sites").contentType(MediaType.APPLICATION_JSON))

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/controller/SiteControllerTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/controller/SiteControllerTests.java
@@ -1,34 +1,37 @@
 package uk.ac.ox.ndph.mts.site_service.controller;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.http.MediaType;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.mockito.Mockito.when;
-import org.mockito.Mockito;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ox.ndph.mts.site_service.exception.InvariantException;
+import uk.ac.ox.ndph.mts.site_service.exception.RestException;
+import uk.ac.ox.ndph.mts.site_service.exception.ValidationException;
+import uk.ac.ox.ndph.mts.site_service.model.Site;
+import uk.ac.ox.ndph.mts.site_service.service.SiteService;
 
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import uk.ac.ox.ndph.mts.site_service.exception.InvariantException;
-import uk.ac.ox.ndph.mts.site_service.model.Site;
-import uk.ac.ox.ndph.mts.site_service.service.SiteService;
-import uk.ac.ox.ndph.mts.site_service.exception.RestException;
-import uk.ac.ox.ndph.mts.site_service.exception.ValidationException;
-
-import java.util.Collections;
-
 @SpringBootTest(properties = { "server.error.include-message=always" })
 @AutoConfigureMockMvc
 class SiteControllerTests {
+
+    private static final String SITES_ROUTE = "/sites";
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -39,7 +42,7 @@ class SiteControllerTests {
     void TestPostSite_WhenNoInput_Returns400() throws Exception {
 
         // Act + Assert
-        this.mockMvc.perform(post("/sites").contentType(MediaType.APPLICATION_JSON))
+        this.mockMvc.perform(post(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON))
                 .andDo(print()).andExpect(status().isBadRequest());
     }
 
@@ -50,7 +53,7 @@ class SiteControllerTests {
         String jsonString = "{\"name\": \"name\", \"alias\": \"alias\"}";
         // Act + Assert
         this.mockMvc
-                .perform(post("/sites").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isCreated()).andExpect(content().string(containsString("123")));
     }
 
@@ -61,7 +64,7 @@ class SiteControllerTests {
         String jsonString = "{\"name\": \"name\", \"alias\": \"alias\"}";
         // Act + Assert
         this.mockMvc
-                .perform(post("/sites").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isCreated()).andExpect(content().string(containsString("123")));
     }
 
@@ -73,7 +76,7 @@ class SiteControllerTests {
 
         // Act + Assert
         this.mockMvc
-                .perform(post("/sites").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isBadGateway());
     }
 
@@ -85,7 +88,7 @@ class SiteControllerTests {
 
         // Act + Assert
         String error = this.mockMvc
-                .perform(post("/sites").contentType(MediaType.APPLICATION_JSON).content(jsonString))
+                .perform(post(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON).content(jsonString))
                 .andDo(print()).andExpect(status().isUnprocessableEntity()).andReturn().getResolvedException().getMessage();
         assertThat(error, containsString("name"));
     }
@@ -97,7 +100,7 @@ class SiteControllerTests {
         when(siteService.findSites()).thenThrow(new InvariantException("root"));
         // Act + Assert
         final String error = this.mockMvc
-                .perform(get("/sites").contentType(MediaType.APPLICATION_JSON))
+                .perform(get(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotImplemented()).andReturn().getResolvedException().getMessage();
         assertThat(error, containsString("root"));
 
@@ -109,7 +112,7 @@ class SiteControllerTests {
         when(siteService.findSites()).thenReturn(Collections.singletonList(new Site("CCO", "Root")));
         // act
         final String result = this.mockMvc
-                .perform(get("/sites").contentType(MediaType.APPLICATION_JSON))
+                .perform(get(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
         // assert - not perfect as need to parse to a JSON object to check keys/values properly
         assertThat(result, stringContainsInOrder("\"name\":", "\"CCO\""));
@@ -123,7 +126,7 @@ class SiteControllerTests {
         when(siteService.findSites()).thenThrow(RestException.class);
         // Act + Assert
         this.mockMvc
-                .perform(get("/sites").contentType(MediaType.APPLICATION_JSON))
+                .perform(get(SITES_ROUTE).contentType(MediaType.APPLICATION_JSON))
                 .andDo(print()).andExpect(status().isBadGateway());
     }
 

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverterTest.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverterTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -13,75 +14,77 @@ import static org.hamcrest.Matchers.nullValue;
 
 class SiteConverterTest {
 
+    private static final String SERVER_ORG_ID = "http://fhir-api/Organization/0d24d8bd-b6ba-4742-96fa-68636dafb487";
+    private static final String SERVER_PARENT_ID = "http://fhir-api/Organization/cccccccc-ccc-cccc-cccc-cccccccccccc";
+    private static final String ORG_NAME = "The Organization";
+    private static final String ORG_ALIAS = "aka-org";
+
+    private final SiteConverter siteConverter = new SiteConverter();
+
     @Test
-    void TestConvert_AllPropertiesSpecified_returnsMatchingSite() throws Exception {
+    void TestConvert_AllPropertiesSpecified_returnsMatchingSite() {
         // arrange
-        final String alias = "the-alias";
-        final String parentId = "the-parent-id";
         final Organization org = new Organization();
-        org.setName("the-name");
-        org.setId("the-id");
-        org.addAlias(alias);
-        org.setPartOf(new Reference("Organization/" + parentId));
+        org.setName(ORG_NAME);
+        org.setId(SERVER_ORG_ID);
+        org.addAlias(ORG_ALIAS);
+        org.setPartOf(new Reference(SERVER_PARENT_ID));
         // act
-        final Site site = new SiteConverter().convert(org);
+        final Site site = siteConverter.convert(org);
         // assert
         assertThat(site.getName(), is(equalTo(org.getName())));
-        assertThat(site.getSiteId(), is(equalTo(org.getId())));
-        assertThat(site.getAlias(), is(equalTo(alias)));
-        assertThat(site.getParentSiteId(), is(equalTo(parentId)));
+        assertThat(SERVER_ORG_ID, containsString(site.getSiteId()));
+        assertThat(site.getAlias(), is(equalTo(ORG_ALIAS)));
+        assertThat(SERVER_PARENT_ID, containsString(site.getParentSiteId()));
     }
 
     @Test
-    void TestConvert_NotPartof_returnsSiteWithNoParent() throws Exception {
+    void TestConvert_NotPartof_returnsSiteWithNoParent() {
         // arrange
-        final String alias = "the-alias";
         final Organization org = new Organization();
-        org.setName("the-name");
-        org.setId("the-id");
-        org.addAlias(alias);
+        org.setName(ORG_NAME);
+        org.setId(SERVER_ORG_ID);
+        org.addAlias(ORG_ALIAS);
         // act
-        final Site site = new SiteConverter().convert(org);
+        final Site site = siteConverter.convert(org);
         // assert
         assertThat(site.getName(), is(equalTo(org.getName())));
-        assertThat(site.getSiteId(), is(equalTo(org.getId())));
-        assertThat(site.getAlias(), is(equalTo(alias)));
+        assertThat(SERVER_ORG_ID, containsString(site.getSiteId()));
+        assertThat(site.getAlias(), is(equalTo(ORG_ALIAS)));
         assertThat(site.getParentSiteId(), is(nullValue()));
     }
 
     @Test
-    void TestConvert_NoAlias_returnsSiteWithoutAlias() throws Exception {
+    void TestConvert_NoAlias_returnsSiteWithoutAlias() {
         // arrange
-        final String parentId = "the-parent-id";
         final Organization org = new Organization();
-        org.setName("the-name");
-        org.setId("the-id");
-        org.setPartOf(new Reference("Organization/" + parentId));
+        org.setName(ORG_NAME);
+        org.setId(SERVER_ORG_ID);
+        org.setPartOf(new Reference(SERVER_PARENT_ID));
         // act
-        final Site site = new SiteConverter().convert(org);
+        final Site site = siteConverter.convert(org);
         // assert
         assertThat(site.getName(), is(equalTo(org.getName())));
-        assertThat(site.getSiteId(), is(equalTo(org.getId())));
+        assertThat(SERVER_ORG_ID, containsString(site.getSiteId()));
         assertThat(site.getAlias(), is(nullValue()));
-        assertThat(site.getParentSiteId(), is(equalTo(parentId)));
+        assertThat(SERVER_PARENT_ID, containsString(site.getParentSiteId()));
     }
 
     @Test
-    void TestConvert_NullAlias_returnsSiteWithoutAlias() throws Exception {
+    void TestConvert_NullAlias_returnsSiteWithoutAlias() {
         // arrange
-        final String parentId = "the-parent-id";
         final Organization org = new Organization();
-        org.setName("the-name");
-        org.setId("the-id");
-        org.setPartOf(new Reference("Organization/" + parentId));
+        org.setName(ORG_NAME);
+        org.setId(SERVER_ORG_ID);
+        org.setPartOf(new Reference(SERVER_PARENT_ID));
         org.addAlias(null);
         // act
-        final Site site = new SiteConverter().convert(org);
+        final Site site = siteConverter.convert(org);
         // assert
         assertThat(site.getName(), is(equalTo(org.getName())));
-        assertThat(site.getSiteId(), is(equalTo(org.getId())));
+        assertThat(SERVER_ORG_ID, containsString(site.getSiteId()));
         assertThat(site.getAlias(), is(nullValue()));
-        assertThat(site.getParentSiteId(), is(equalTo(parentId)));
+        assertThat(SERVER_PARENT_ID, containsString(site.getParentSiteId()));
     }
 
 }

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverterTest.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverterTest.java
@@ -1,0 +1,87 @@
+package uk.ac.ox.ndph.mts.site_service.converter;
+
+import org.hl7.fhir.r4.model.Organization;
+import org.hl7.fhir.r4.model.Reference;
+import org.junit.jupiter.api.Test;
+import uk.ac.ox.ndph.mts.site_service.model.Site;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+
+class SiteConverterTest {
+
+    @Test
+    void TestConvert_AllPropertiesSpecified_returnsMatchingSite() throws Exception {
+        // arrange
+        final String alias = "the-alias";
+        final String parentId = "the-parent-id";
+        final Organization org = new Organization();
+        org.setName("the-name");
+        org.setId("the-id");
+        org.addAlias(alias);
+        org.setPartOf(new Reference("Organization/" + parentId));
+        // act
+        final Site site = new SiteConverter().convert(org);
+        // assert
+        assertThat(site.getName(), is(equalTo(org.getName())));
+        assertThat(site.getSiteId(), is(equalTo(org.getId())));
+        assertThat(site.getAlias(), is(equalTo(alias)));
+        assertThat(site.getParentSiteId(), is(equalTo(parentId)));
+    }
+
+    @Test
+    void TestConvert_NotPartof_returnsSiteWithNoParent() throws Exception {
+        // arrange
+        final String alias = "the-alias";
+        final Organization org = new Organization();
+        org.setName("the-name");
+        org.setId("the-id");
+        org.addAlias(alias);
+        // act
+        final Site site = new SiteConverter().convert(org);
+        // assert
+        assertThat(site.getName(), is(equalTo(org.getName())));
+        assertThat(site.getSiteId(), is(equalTo(org.getId())));
+        assertThat(site.getAlias(), is(equalTo(alias)));
+        assertThat(site.getParentSiteId(), is(nullValue()));
+    }
+
+    @Test
+    void TestConvert_NoAlias_returnsSiteWithoutAlias() throws Exception {
+        // arrange
+        final String parentId = "the-parent-id";
+        final Organization org = new Organization();
+        org.setName("the-name");
+        org.setId("the-id");
+        org.setPartOf(new Reference("Organization/" + parentId));
+        // act
+        final Site site = new SiteConverter().convert(org);
+        // assert
+        assertThat(site.getName(), is(equalTo(org.getName())));
+        assertThat(site.getSiteId(), is(equalTo(org.getId())));
+        assertThat(site.getAlias(), is(nullValue()));
+        assertThat(site.getParentSiteId(), is(equalTo(parentId)));
+    }
+
+    @Test
+    void TestConvert_NullAlias_returnsSiteWithoutAlias() throws Exception {
+        // arrange
+        final String parentId = "the-parent-id";
+        final Organization org = new Organization();
+        org.setName("the-name");
+        org.setId("the-id");
+        org.setPartOf(new Reference("Organization/" + parentId));
+        org.addAlias(null);
+        // act
+        final Site site = new SiteConverter().convert(org);
+        // assert
+        assertThat(site.getName(), is(equalTo(org.getName())));
+        assertThat(site.getSiteId(), is(equalTo(org.getId())));
+        assertThat(site.getAlias(), is(nullValue()));
+        assertThat(site.getParentSiteId(), is(equalTo(parentId)));
+    }
+
+}

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepositoryTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepositoryTests.java
@@ -1,15 +1,7 @@
 package uk.ac.ox.ndph.mts.site_service.repository;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-
-import java.util.Collection;
-import java.util.List;
-
 import ca.uhn.fhir.rest.gclient.IQuery;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.ResearchStudy;
@@ -19,8 +11,16 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import uk.ac.ox.ndph.mts.site_service.exception.RestException;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class HapiFhirRepositoryTests {
@@ -164,7 +164,7 @@ class HapiFhirRepositoryTests {
         when(fhirContextWrapper.toListOfResourcesOfType(any(Bundle.class), eq(Organization.class))).thenReturn(List.of(org));
         final var fhirRepository =  new HapiFhirRepository(fhirContextWrapper);
         // act
-        final Collection<Organization> orgs = fhirRepository.getOrganizations();
+        final Collection<Organization> orgs = fhirRepository.findOrganizations();
         // assert
         verify(mockQuery).execute();
         assertThat(orgs, is(not(empty())));
@@ -177,7 +177,7 @@ class HapiFhirRepositoryTests {
         when(fhirContextWrapper.search(anyString(), eq(Organization.class))).thenThrow(new ResourceNotFoundException("error"));
         var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
         // Act + Assert
-        assertThrows(RestException.class, () -> fhirRepository.getOrganizations());
+        assertThrows(RestException.class, fhirRepository::findOrganizations);
     }
 
 }

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepositoryTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepositoryTests.java
@@ -160,7 +160,7 @@ class HapiFhirRepositoryTests {
                 .setResource(org);
         final var mockQuery = mockQuery();
         when(mockQuery.execute()).thenReturn(responseBundle);
-        when(fhirContextWrapper.search(anyString(), eq("Organization"))).thenReturn(mockQuery);
+        when(fhirContextWrapper.search(anyString(), eq(Organization.class))).thenReturn(mockQuery);
         when(fhirContextWrapper.toListOfResourcesOfType(any(Bundle.class), eq(Organization.class))).thenReturn(List.of(org));
         final var fhirRepository =  new HapiFhirRepository(fhirContextWrapper);
         // act
@@ -174,7 +174,7 @@ class HapiFhirRepositoryTests {
 
     @Test
     void TestHapiRepository_getOrganizations_WhenContextWrapperThrowsExpected_ThrowsRestException() {
-        when(fhirContextWrapper.search(anyString(), anyString())).thenThrow(new ResourceNotFoundException("error"));
+        when(fhirContextWrapper.search(anyString(), eq(Organization.class))).thenThrow(new ResourceNotFoundException("error"));
         var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
         // Act + Assert
         assertThrows(RestException.class, () -> fhirRepository.getOrganizations());

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepositoryTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepositoryTests.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import java.util.Collection;

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepositoryTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/repository/HapiFhirRepositoryTests.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import java.util.Collection;
@@ -36,7 +37,7 @@ class HapiFhirRepositoryTests {
     {
         // Arrange
         var responseBundle = new Bundle();
-        when(fhirContextWrapper.executeTrasaction(anyString(), any(Bundle.class))).thenReturn(responseBundle);
+        when(fhirContextWrapper.executeTransaction(anyString(), any(Bundle.class))).thenReturn(responseBundle);
         when(fhirContextWrapper.toListOfResources(any(Bundle.class))).thenReturn(List.of(new Organization()));
         var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
 
@@ -46,7 +47,7 @@ class HapiFhirRepositoryTests {
         fhirRepository.saveOrganization(organization);
 
         // Assert
-        verify(fhirContextWrapper).executeTrasaction(anyString(), bundleCaptor.capture());
+        verify(fhirContextWrapper).executeTransaction(anyString(), bundleCaptor.capture());
         var value = bundleCaptor.getValue();
         var type = value.getType();
         assertThat(type, equalTo(Bundle.BundleType.TRANSACTION));
@@ -57,7 +58,7 @@ class HapiFhirRepositoryTests {
     {
         // Arrange
         var responseBundle = new Bundle();
-        when(fhirContextWrapper.executeTrasaction(anyString(), any(Bundle.class))).thenReturn(responseBundle);
+        when(fhirContextWrapper.executeTransaction(anyString(), any(Bundle.class))).thenReturn(responseBundle);
         when(fhirContextWrapper.toListOfResources(any(Bundle.class))).thenReturn(List.of(new ResearchStudy()));
         var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
 
@@ -67,7 +68,7 @@ class HapiFhirRepositoryTests {
         fhirRepository.saveResearchStudy(researchStudy);
 
         // Assert
-        verify(fhirContextWrapper).executeTrasaction(anyString(), bundleCaptor.capture());
+        verify(fhirContextWrapper).executeTransaction(anyString(), bundleCaptor.capture());
         var value = bundleCaptor.getValue();
         var type = value.getType();
         assertThat(type, equalTo(Bundle.BundleType.TRANSACTION));
@@ -75,7 +76,7 @@ class HapiFhirRepositoryTests {
     
     @Test
     void TestHapiRepository_WhenContextWrapperThrowsExpected_ThrowsRestException(){
-        when(fhirContextWrapper.executeTrasaction(anyString(), any(Bundle.class))).thenThrow(new ResourceNotFoundException("error"));
+        when(fhirContextWrapper.executeTransaction(anyString(), any(Bundle.class))).thenThrow(new ResourceNotFoundException("error"));
         var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
         var organization = new Organization();
         
@@ -87,7 +88,7 @@ class HapiFhirRepositoryTests {
     void TestHapiRepository_WhenContextReturnsMalformedBundle_ThrowsRestException(){
         // Arrange
         var responseBundle = new Bundle();
-        when(fhirContextWrapper.executeTrasaction(anyString(), any(Bundle.class))).thenReturn(responseBundle);
+        when(fhirContextWrapper.executeTransaction(anyString(), any(Bundle.class))).thenReturn(responseBundle);
         when(fhirContextWrapper.toListOfResources(any(Bundle.class))).thenReturn(List.of(new Organization(), new Organization()));
         var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
         var organization = new Organization();
@@ -99,7 +100,7 @@ class HapiFhirRepositoryTests {
     @Test
     void TestHapiRepository_WhenContextReturnsNull_ThrowsRestException(){
         // Arrange
-        when(fhirContextWrapper.executeTrasaction(anyString(), any(Bundle.class))).thenReturn(null);
+        when(fhirContextWrapper.executeTransaction(anyString(), any(Bundle.class))).thenReturn(null);
 
         var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
         var organization = new Organization();
@@ -110,7 +111,7 @@ class HapiFhirRepositoryTests {
 
     @Test
     void TestHapiRepository_WhenContextWrapperResearchStudyThrowsExpected_ThrowsRestException(){
-        when(fhirContextWrapper.executeTrasaction(anyString(), any(Bundle.class))).thenThrow(new ResourceNotFoundException("error"));
+        when(fhirContextWrapper.executeTransaction(anyString(), any(Bundle.class))).thenThrow(new ResourceNotFoundException("error"));
         var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
         var researchStudy = new ResearchStudy();
 
@@ -122,7 +123,7 @@ class HapiFhirRepositoryTests {
     void TestHapiRepository_WhenContextReturnsMalformedBundleResearchStudy_ThrowsRestException(){
         // Arrange
         var responseBundle = new Bundle();
-        when(fhirContextWrapper.executeTrasaction(anyString(), any(Bundle.class))).thenReturn(responseBundle);
+        when(fhirContextWrapper.executeTransaction(anyString(), any(Bundle.class))).thenReturn(responseBundle);
         when(fhirContextWrapper.toListOfResources(any(Bundle.class))).thenReturn(List.of(new ResearchStudy(), new ResearchStudy()));
         var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
         var researchStudy = new ResearchStudy();
@@ -134,7 +135,7 @@ class HapiFhirRepositoryTests {
     @Test
     void TestHapiRepository_WhenContextReturnsNullResearchStudy_ThrowsRestException(){
         // Arrange
-        when(fhirContextWrapper.executeTrasaction(anyString(), any(Bundle.class))).thenReturn(null);
+        when(fhirContextWrapper.executeTransaction(anyString(), any(Bundle.class))).thenReturn(null);
 
         var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
         var researchStudy = new ResearchStudy();
@@ -170,6 +171,14 @@ class HapiFhirRepositoryTests {
         assertThat(orgs, is(not(empty())));
         assertThat(orgs.size(), is(1));
         assertThat(orgs, hasItem(hasProperty("name", equalTo("CCO"))));
+    }
+
+    @Test
+    void TestHapiRepository_getOrganizations_WhenContextWrapperThrowsExpected_ThrowsRestException() {
+        when(fhirContextWrapper.search(anyString(), anyString())).thenThrow(new ResourceNotFoundException("error"));
+        var fhirRepository = new HapiFhirRepository(fhirContextWrapper);
+        // Act + Assert
+        assertThrows(RestException.class, () -> fhirRepository.getOrganizations());
     }
 
 }

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/service/SiteServiceImplTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/service/SiteServiceImplTests.java
@@ -103,9 +103,9 @@ class SiteServiceImplTests {
     void TestGetSites_WhenEmpty_ThrowsInvariantException() {
         // arrange
         final var siteService = new SiteServiceImpl(siteStore, siteValidation);
-        when(siteStore.geAllEntities()).thenReturn(Collections.emptyList());
+        when(siteStore.findAll()).thenReturn(Collections.emptyList());
         // act + assert
-        Assertions.assertThrows(InvariantException.class, () -> siteService.getSites(),
+        Assertions.assertThrows(InvariantException.class, () -> siteService.findSites(),
                 "Expecting getSites to throw invariant exception");
     }
 
@@ -114,9 +114,9 @@ class SiteServiceImplTests {
         // arrange
         final var siteService = new SiteServiceImpl(siteStore, siteValidation);
         final var site = new Site("CCO", "Root", null);
-        when(siteStore.geAllEntities()).thenReturn(Collections.singletonList(site));
+        when(siteStore.findAll()).thenReturn(Collections.singletonList(site));
         // act
-        final List<Site> sites = siteService.getSites();
+        final List<Site> sites = siteService.findSites();
         // assert
         assertThat(sites, is(not(empty())));
         assertThat(sites, hasItem(samePropertyValuesAs(site)));

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/service/SiteServiceImplTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/service/SiteServiceImplTests.java
@@ -14,21 +14,25 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import uk.ac.ox.ndph.mts.site_service.exception.InitialisationError;
+import uk.ac.ox.ndph.mts.site_service.exception.InvariantException;
 import uk.ac.ox.ndph.mts.site_service.exception.ValidationException;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
 import uk.ac.ox.ndph.mts.site_service.model.ValidationResponse;
 import uk.ac.ox.ndph.mts.site_service.repository.EntityStore;
 import uk.ac.ox.ndph.mts.site_service.validation.ModelEntityValidation;
 
+import java.util.Collections;
+import java.util.List;
+
 @ExtendWith(MockitoExtension.class)
 class SiteServiceImplTests {
-    
+
     @Mock
     private EntityStore<Site> siteStore;
 
     @Mock
     private ModelEntityValidation<Site> siteValidation;
-    
+
     @Captor
     ArgumentCaptor<Site> siteCaptor;
 
@@ -55,7 +59,7 @@ class SiteServiceImplTests {
     }
 
     @Test
-    void TestSaveSite_WhenValidSite_SavesToStore(){
+    void TestSaveSite_WhenValidSite_SavesToStore() {
         // Arrange
         String name = "name";
         String alias = "alias";
@@ -73,7 +77,7 @@ class SiteServiceImplTests {
     }
 
     @Test
-    void TestSaveSite_WhenInvalidSite_ThrowsValidationException_DoesntSavesToStore(){
+    void TestSaveSite_WhenInvalidSite_ThrowsValidationException_DoesntSavesToStore() {
         // Arrange
         String name = "name";
         String alias = "alias";
@@ -87,11 +91,35 @@ class SiteServiceImplTests {
     }
 
     @Test
-    void TestSiteServiceImpl_WhenNullValues_ThrowsInitialisationError(){
+    void TestSiteServiceImpl_WhenNullValues_ThrowsInitialisationError() {
         // Arrange + Act + Assert
         Assertions.assertThrows(InitialisationError.class, () -> new SiteServiceImpl(null, siteValidation),
                 "null store should throw");
         Assertions.assertThrows(InitialisationError.class, () -> new SiteServiceImpl(siteStore, null),
                 "null validation should throw");
     }
+
+    @Test
+    void TestGetSites_WhenEmpty_ThrowsInvariantException() {
+        // arrange
+        final var siteService = new SiteServiceImpl(siteStore, siteValidation);
+        when(siteStore.geAllEntities()).thenReturn(Collections.emptyList());
+        // act + assert
+        Assertions.assertThrows(InvariantException.class, () -> siteService.getSites(),
+                "Expecting getSites to throw invariant exception");
+    }
+
+    @Test
+    void TestGetSites_WhenStoreHasSites_ReturnsSites() {
+        // arrange
+        final var siteService = new SiteServiceImpl(siteStore, siteValidation);
+        final var site = new Site("CCO", "Root", null);
+        when(siteStore.geAllEntities()).thenReturn(Collections.singletonList(site));
+        // act
+        final List<Site> sites = siteService.getSites();
+        // assert
+        assertThat(sites, is(not(empty())));
+        assertThat(sites, hasItem(samePropertyValuesAs(site)));
+    }
+
 }

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/validation/SiteValidationTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/validation/SiteValidationTests.java
@@ -1,6 +1,5 @@
 package uk.ac.ox.ndph.mts.site_service.validation;
 
-import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;


### PR DESCRIPTION
## Description

* Added get-all-sites endpoint to site-service `GET ${site-service}/sites`
* Added new endpoint (translating from the FHIR API), matching tests, updated README to document API.
* Site model now has site ID (the FHIR ID), required for matching parentSiteId

### Changes
- [ARTS-404] - get sites from site service

### Checklist:

- [X] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [X] I have included a short-meaningful title, description and changes for this PR


[ARTS-404]: https://ndph-arts.atlassian.net/browse/ARTS-404