### PR TITLE
[ARTS-610] New GET endpoint in role-service to return multiple roles by ID

### DIFF
--- a/role-service/src/main/java/uk/ac/ox/ndph/mts/role_service/controller/RoleController.java
+++ b/role-service/src/main/java/uk/ac/ox/ndph/mts/role_service/controller/RoleController.java
@@ -52,9 +52,14 @@ public class RoleController {
         return retrievedRole.get();
     }
 
-    @GetMapping("")
+    @GetMapping(params = {"page", "size"})
     public Page<Role> getPaged(@RequestParam int page, @RequestParam int size) {
         return roleRepository.findAll(PageRequest.of(page, size));
+    }
+
+    @GetMapping(params = "ids")
+    public Iterable<Role> getByIds(@RequestParam List<String> ids) {
+        return roleRepository.findAllById(ids);
     }
 
 

--- a/role-service/src/test/java/uk/ac/ox/ndph/mts/role_service/controller/RoleControllerTest.java
+++ b/role-service/src/test/java/uk/ac/ox/ndph/mts/role_service/controller/RoleControllerTest.java
@@ -32,6 +32,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(RoleController.class)
@@ -163,23 +164,31 @@ class RoleControllerTest {
     }
 
     @Test
-    void whenGetMultipleRolesById_thenReceiveMultipleRoles() throws Exception {
+    void whenGetMultipleRolesById_thenReceiveMultipleRolesAndPermissionsJson() throws Exception {
 
         Role dummyRole1 = new Role();
-        String id1 = "foo";
-        dummyRole1.setId(id1);
+        String roleId1 = "foo";
+        dummyRole1.setId(roleId1);
         Role dummyRole2 = new Role();
-        String id2 = "bar";
-        dummyRole2.setId(id2);
+        String roleId2 = "bar";
+        dummyRole2.setId(roleId2);
+        Permission dummyPermission = new Permission();
+        String permId = "baz";
+        dummyPermission.setId(permId);
+        dummyRole2.setPermissions(Collections.singletonList(dummyPermission));
 
-        when(roleRepo.findAllById(Arrays.asList(id1, id2)))
+        when(roleRepo.findAllById(Arrays.asList(roleId1, roleId2)))
                 .thenReturn(Arrays.asList(dummyRole1, dummyRole2));
 
-        mvc.perform(get(URI_ROLES + "?ids=" + id1 + "," + id2))
+        mvc.perform(get(URI_ROLES + "?ids=" + roleId1 + "," + roleId2))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString(id1)))
-                .andExpect(content().string(containsString(id2)));
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].id").value(roleId1))
+                .andExpect(jsonPath("$[1].id").value(roleId2))
+                .andExpect(jsonPath("$[1].permissions[0].id").value(permId));
+
+
     }
 
 }

--- a/role-service/src/test/java/uk/ac/ox/ndph/mts/role_service/controller/RoleControllerTest.java
+++ b/role-service/src/test/java/uk/ac/ox/ndph/mts/role_service/controller/RoleControllerTest.java
@@ -11,7 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import uk.ac.ox.ndph.mts.role_service.controller.dtos.PermissionDTO;
 import uk.ac.ox.ndph.mts.role_service.controller.dtos.RoleDTO;
@@ -24,6 +23,7 @@ import uk.ac.ox.ndph.mts.role_service.service.RoleService;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
+
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/role-service/src/test/java/uk/ac/ox/ndph/mts/role_service/controller/RoleControllerTest.java
+++ b/role-service/src/test/java/uk/ac/ox/ndph/mts/role_service/controller/RoleControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import uk.ac.ox.ndph.mts.role_service.controller.dtos.PermissionDTO;
 import uk.ac.ox.ndph.mts.role_service.controller.dtos.RoleDTO;
@@ -20,6 +21,7 @@ import uk.ac.ox.ndph.mts.role_service.model.Role;
 import uk.ac.ox.ndph.mts.role_service.model.RoleRepository;
 import uk.ac.ox.ndph.mts.role_service.service.RoleService;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import static org.hamcrest.Matchers.containsString;
@@ -105,6 +107,8 @@ class RoleControllerTest {
         mvc.perform(get(URI_ROLES + "?page=0&size=10")).andDo(MockMvcResultHandlers.print()).andExpect(status().isOk());
     }
 
+
+
     @Test
     void whenGetOneRole_thenReceiveSuccess() throws Exception {
 
@@ -156,6 +160,26 @@ class RoleControllerTest {
         mvc.perform(post(uri).contentType(MediaType.APPLICATION_JSON).content(jsonPermDTO)
                 .accept(MediaType.APPLICATION_JSON)).andDo(MockMvcResultHandlers.print()).andExpect(status().isOk());
 
+    }
+
+    @Test
+    void whenGetMultipleRolesById_thenReceiveMultipleRoles() throws Exception {
+
+        Role dummyRole1 = new Role();
+        String id1 = "foo";
+        dummyRole1.setId(id1);
+        Role dummyRole2 = new Role();
+        String id2 = "bar";
+        dummyRole2.setId(id2);
+
+        when(roleRepo.findAllById(Arrays.asList(id1, id2)))
+                .thenReturn(Arrays.asList(dummyRole1, dummyRole2));
+
+        mvc.perform(get(URI_ROLES + "?ids=" + id1 + "," + id2))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString(id1)))
+                .andExpect(content().string(containsString(id2)));
     }
 
 }


### PR DESCRIPTION
## Description
This sub-task enables a performance improvement in the authorisation component ARTS-361 at the point it looks up roles for the user.   See Alex's review of PR  https://github.com/NDPH-ARTS/mts-services/pull/111#discussion_r572121101  
#111
### Changes
- [ARTS-610] Create new api endpoint in role service to get roles by list of ids
- [ARTS-361] Validate user permissions in authorisation

### Checklist:

- [x] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-610]: https://ndph-arts.atlassian.net/browse/ARTS-610
[ARTS-361]: https://ndph-arts.atlassian.net/browse/ARTS-361