### PR TITLE
[ARTS-623] Add dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# git
+.git
+.gitattributes
+.gitignore
+
+# JetBrains
+.idea
+.run
+**/*.iml
+
+# VSCode
+.vscode
+
+# Others
+.devcontainer
+.ci
+**/*.md
+
+# Maven
+**/target
+**/logs
+
+
+# Node
+logs
+**/*.log
+**/npm-debug.log*
+**/yarn-debug.log*
+**/yarn-error.log*
+**/node_modules/


### PR DESCRIPTION
## Description
Add a dockerignore file to remove items from the docker build context that typically exist locally but aren't needed.

### Changes
- [ARTS-623] Add dockerignore file

### Checklist:

- [x] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-623]: https://ndph-arts.atlassian.net/browse/ARTS-623