### PR TITLE
Smaller docker-compose footprint

### DIFF
--- a/.ci/docker/check-docker-compose-services.sh
+++ b/.ci/docker/check-docker-compose-services.sh
@@ -25,27 +25,10 @@ docker-compose pull -q
 docker-compose up --no-build -d practitioner-service role-service site-service
 
 echo "Waiting for docker compose services..."
-
 while ! is_healthy site-service; do sleep 10; done
 while ! is_healthy role-service; do sleep 10; done
 while ! is_healthy practitioner-service; do sleep 10; done
-
 echo "Services started."
-
-    if [ "$health_status" = "healthy" ]; then
-        echo "$1 is healthy"
-        return 0
-    else
-        echo "Waiting for $1"
-        return 1
-    fi
-}
-
-while ! is_healthy site-service; do sleep 10; done
-while ! is_healthy role-service; do sleep 10; done
-while ! is_healthy practitioner-service; do sleep 10; done
-
-echo "Core services started."
 
 
 echo "Running init-service..."
@@ -60,6 +43,6 @@ then
   echo "init-service completed successfully."
   exit 0
 else
-  echo "init-service failure! exit code was: $RUN_EXIT_CODE" >&2
+  echo "init-service failure!" >&2
   exit 1
 fi

--- a/.ci/docker/check-docker-compose-services.sh
+++ b/.ci/docker/check-docker-compose-services.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# This is an lite integration script that bring the services up, and init the system.
+# This is an lite integration script that brings the services up, and init the system.
 
 set -o errexit
 set -o pipefail
@@ -24,7 +24,7 @@ is_healthy() {
 docker-compose pull -q
 docker-compose up --no-build -d practitioner-service role-service site-service
 
-echo "Waiting for docker compose services..."
+echo "Waiting for services to become healthy..."
 while ! is_healthy site-service; do sleep 10; done
 while ! is_healthy role-service; do sleep 10; done
 while ! is_healthy practitioner-service; do sleep 10; done

--- a/.ci/docker/check-docker-compose-services.sh
+++ b/.ci/docker/check-docker-compose-services.sh
@@ -1,7 +1,11 @@
-docker-compose pull -q
-docker-compose up --scale init-service=0 -d --no-build
+#!/usr/bin/env bash
+#
+# This is an lite integration script that bring the services up, and init the system.
 
-echo "Waiting for docker compose services..."
+set -o errexit
+set -o pipefail
+set -o nounset
+# set -o xtrace
 
 is_healthy() {
     service="$1"
@@ -17,8 +21,45 @@ is_healthy() {
     fi
 }
 
-while ! is_healthy site-service; do sleep 10; done
-while ! is_healthy practitioner-service; do sleep 10; done
-while ! is_healthy role-service; do sleep 10; done
+docker-compose pull -q
+docker-compose up --no-build -d practitioner-service role-service site-service
 
-echo "Compose services started."
+echo "Waiting for docker compose services..."
+
+while ! is_healthy site-service; do sleep 10; done
+while ! is_healthy role-service; do sleep 10; done
+while ! is_healthy practitioner-service; do sleep 10; done
+
+echo "Services started."
+
+    if [ "$health_status" = "healthy" ]; then
+        echo "$1 is healthy"
+        return 0
+    else
+        echo "Waiting for $1"
+        return 1
+    fi
+}
+
+while ! is_healthy site-service; do sleep 10; done
+while ! is_healthy role-service; do sleep 10; done
+while ! is_healthy practitioner-service; do sleep 10; done
+
+echo "Core services started."
+
+
+echo "Running init-service..."
+set +o errexit # the run might fail and we'd like to continue the script
+docker-compose run --no-deps init-service
+run_exit_code=$?
+set -o errexit
+
+# check the run command exit code
+if [ $run_exit_code -eq 0 ]
+then
+  echo "init-service completed successfully."
+  exit 0
+else
+  echo "init-service failure! exit code was: $RUN_EXIT_CODE" >&2
+  exit 1
+fi

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Java
+*.java          text diff=java
+*.class         binary
+*.war           binary
+
+# Other text files
+*.xml           text
+*.yml           text
+*.properties    text
+*.md            text
+*.sh            text

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -62,7 +62,7 @@ jobs:
 
   test:
     name: API Integration Tests
-    if: github.event_name == 'pull_request'
+    if: (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -78,10 +78,11 @@ jobs:
           ./.ci/docker/check-docker-compose-services.sh
           npm run --prefix api-tests api-test-ci
           docker-compose down
-      - name: Publish API Test Report
+      - name: Process API Tests Report
         if: always()
         uses: scacap/action-surefire-report@v1
         with:
+          check_name: API Tests Report Check
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: 'api-tests/api-test-results.xml'
           fail_on_test_failures: true

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -72,10 +72,13 @@ jobs:
         timeout-minutes: 5
         env:
           SAPASSWORD: $(openssl rand -base64 12)
-          BASE_URL: http://localhost
           GITHUB_SHA: ${{github.sha}}
         run: |
           ./.ci/docker/check-docker-compose-services.sh
+      - name: Run API Tests
+        env:
+          BASE_URL: http://localhost
+        run: |
           npm run --prefix api-tests api-test-ci
           docker-compose down
       - name: Process API Tests Report

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -33,6 +33,8 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_LOGIN }}
       - name: Build & publish runtime image
+        env:
+          DOCKER_BUILDKIT: 1
         run: |
           set -o errexit
           set -o nounset
@@ -83,3 +85,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: 'api-tests/api-test-results.xml'
           fail_on_test_failures: true
+          fail_if_no_tests: true

--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -21,14 +21,14 @@ COPY ./role-service/pom.xml ./role-service/
 COPY ./site-service/pom.xml ./site-service/
 
 # cache most dependencies as a layer to be used in other builds while POMs don't change
-RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+RUN mvn dependency:go-offline --batch-mode -q -Dmaven.wagon.http.retryHandler.count=3 --projects ${SVC}
 
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 
-RUN mvn package --projects ${SVC} # -Dmaven.test.failure.ignore=true
+RUN mvn package --projects ${SVC}
 
-FROM openjdk:11.0.9.1-jre-buster
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-debianslim
 ARG SVC
 ARG JAR_FILE=${SVC}/target/*.jar
 COPY --from=builder ${JAR_FILE} app.jar

--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -21,14 +21,14 @@ COPY ./role-service/pom.xml ./role-service/
 COPY ./site-service/pom.xml ./site-service/
 
 # cache most dependencies as a layer to be used in other builds while POMs don't change
-RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+RUN mvn dependency:go-offline --batch-mode -q -Dmaven.wagon.http.retryHandler.count=3 --projects ${SVC}
 
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 
 RUN mvn package --projects ${SVC}
 
-FROM openjdk:11.0.9.1-jre-buster
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-debianslim
 ARG SVC
 ARG JAR_FILE=${SVC}/target/*.jar
 COPY --from=builder ${JAR_FILE} app.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,12 +40,12 @@ services:
         SVC: role-service
     image: ghcr.io/ndph-arts/role-service:${GITHUB_SHA}
     depends_on:
-      sql-mts-data:
+      sql:
         condition: service_healthy
     environment:
       SERVER_PORT: "8082"
       JDBC_DRIVER: com.microsoft.sqlserver.jdbc.SQLServerDriver
-      JDBC_URL: jdbc:sqlserver://sql-mts-data:1433;databaseName=master;user=sa;password=${SAPASSWORD};loginTimeout=15
+      JDBC_URL: jdbc:sqlserver://sql:1433;databaseName=master;user=sa;password=${SAPASSWORD};loginTimeout=15
       SPRING_PROFILES_ACTIVE: ${PROFILE:-local}
     healthcheck:
       test: curl http://localhost:8082
@@ -83,6 +83,8 @@ services:
   # SUPPORTING SERVICES #
   #######################
   init-service:
+    # profiles:
+    #   - init
     build:
       context: .
       dockerfile: init-service/Dockerfile
@@ -96,6 +98,9 @@ services:
       SITE_SERVICE: "http://site-service:8083"
       CONFIG_JSON: config.json
       SPRING_PROFILES_ACTIVE: ${PROFILE:-local}
+    deploy:
+      restart_policy:
+          condition: none
     depends_on:
       practitioner-service:
         condition: service_healthy
@@ -109,7 +114,7 @@ services:
     restart: on-failure
     environment:
       FHIRServer__Security__Enabled: "false"
-      SqlServer__ConnectionString: "Server=tcp:sql-fhir,1433;Initial Catalog=FHIR;Persist Security Info=False;User ID=sa;Password=${SAPASSWORD};MultipleActiveResultSets=False;Connection Timeout=30;"
+      SqlServer__ConnectionString: "Server=tcp:sql,1433;Initial Catalog=FHIR;Persist Security Info=False;User ID=sa;Password=${SAPASSWORD};MultipleActiveResultSets=False;Connection Timeout=30;"
       SqlServer__AllowDatabaseCreation: "true"
       SqlServer__SchemaOptions__AutomaticUpdatesEnabled: "true"
       SqlServer__Initialize: "true"
@@ -117,12 +122,14 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - sql-fhir
+      - sql
 
   #########################
   # SPRING CLOUD SERVICES #
   #########################
   config-server:
+    # profiles:
+    #   - springcloud
     build:
       context: .
       dockerfile: config-server/Dockerfile
@@ -144,6 +151,8 @@ services:
       retries: 6 # a quick service
 
   discovery-server:
+    # profiles:
+    #   - springcloud
     build:
       context: .
       dockerfile: discovery-server/Dockerfile
@@ -187,7 +196,7 @@ services:
   # DATABASES #
   #############
 
-  sql-fhir:
+  sql:
     image: "mcr.microsoft.com/mssql/server"
     environment:
       SA_PASSWORD: ${SAPASSWORD}
@@ -199,18 +208,3 @@ services:
       retries: 6
     ports:
       - "1433:1433"
-
-  sql-mts-data:
-    image: "mcr.microsoft.com/mssql/server"
-    environment:
-      SA_PASSWORD: ${SAPASSWORD}
-      ACCEPT_EULA: "Y"
-    healthcheck:
-      test: [ "CMD", "/opt/mssql-tools/bin/sqlcmd","-U sa -P ${SAPASSWORD} -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" ]
-      interval: 10s
-      timeout: 10s
-      retries: 6
-    ports:
-      - "1434:1433"
-
-

--- a/init-service/Dockerfile
+++ b/init-service/Dockerfile
@@ -21,14 +21,14 @@ COPY ./role-service/pom.xml ./role-service/
 COPY ./site-service/pom.xml ./site-service/
 
 # cache most dependencies as a layer to be used in other builds while POMs don't change
-RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+RUN mvn dependency:go-offline --batch-mode -q -Dmaven.wagon.http.retryHandler.count=3 --projects ${SVC}
 
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 
-RUN mvn package --projects ${SVC} # -Dmaven.test.failure.ignore=true
+RUN mvn package --projects ${SVC}
 
-FROM openjdk:11.0.9.1-jre-buster
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-debianslim
 ARG SVC
 ARG JAR_FILE=${SVC}/target/*.jar
 COPY --from=builder ${JAR_FILE} app.jar

--- a/init-service/src/main/resources/application.properties
+++ b/init-service/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# init-service is just a console app, should quit when done.
+spring.main.web-application-type=NONE
+
 spring.hateoas.use-hal-as-default-json-media-type=false
 
 # Log properties in application.properties

--- a/practitioner-service/Dockerfile
+++ b/practitioner-service/Dockerfile
@@ -21,14 +21,14 @@ COPY ./role-service/pom.xml ./role-service/
 COPY ./site-service/pom.xml ./site-service/
 
 # cache most dependencies as a layer to be used in other builds while POMs don't change
-RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+RUN mvn dependency:go-offline --batch-mode -q -Dmaven.wagon.http.retryHandler.count=3 --projects ${SVC}
 
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 
 RUN mvn package --batch-mode -q --projects ${SVC}
 
-FROM openjdk:11.0.9.1-jre-buster
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-debianslim
 ARG SVC
 ARG JAR_FILE=${SVC}/target/*.jar
 COPY --from=builder ${JAR_FILE} app.jar

--- a/role-service/Dockerfile
+++ b/role-service/Dockerfile
@@ -21,14 +21,14 @@ COPY ./role-service/pom.xml ./role-service/
 COPY ./site-service/pom.xml ./site-service/
 
 # cache most dependencies as a layer to be used in other builds while POMs don't change
-RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+RUN mvn dependency:go-offline --batch-mode -q -Dmaven.wagon.http.retryHandler.count=3 --projects ${SVC}
 
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 
 RUN mvn package --batch-mode -q --projects ${SVC}
 
-FROM openjdk:11.0.9.1-jre-buster
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-debianslim
 ARG SVC
 ARG JAR_FILE=${SVC}/target/*.jar
 COPY --from=builder ${JAR_FILE} app.jar

--- a/sample-service/Dockerfile
+++ b/sample-service/Dockerfile
@@ -21,14 +21,14 @@ COPY ./role-service/pom.xml ./role-service/
 COPY ./site-service/pom.xml ./site-service/
 
 # cache most dependencies as a layer to be used in other builds while POMs don't change
-RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+RUN mvn dependency:go-offline --batch-mode -q -Dmaven.wagon.http.retryHandler.count=3 --projects ${SVC}
 
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 
 RUN mvn package --batch-mode -q --projects ${SVC}
 
-FROM openjdk:11.0.9.1-jre-buster
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-debianslim
 ARG SVC
 ARG JAR_FILE=${SVC}/target/*.jar
 COPY --from=builder ${JAR_FILE} app.jar

--- a/site-service/Dockerfile
+++ b/site-service/Dockerfile
@@ -21,14 +21,14 @@ COPY ./role-service/pom.xml ./role-service/
 COPY ./site-service/pom.xml ./site-service/
 
 # cache most dependencies as a layer to be used in other builds while POMs don't change
-RUN mvn dependency:go-offline --batch-mode -q --projects ${SVC}
+RUN mvn dependency:go-offline --batch-mode -q -Dmaven.wagon.http.retryHandler.count=3 --projects ${SVC}
 
 # copy current service source
 COPY ./${SVC}/src ${SVC}/src
 
 RUN mvn package --projects ${SVC}
 
-FROM openjdk:11.0.9.1-jre-buster
+FROM openjdk:11.0.10-jre-buster
 ARG SVC
 ARG JAR_FILE=${SVC}/target/*.jar
 COPY --from=builder ${JAR_FILE} app.jar


### PR DESCRIPTION
## Description
Make some changed to lower the requirements of running the system via docker-compose, plus some other small fixes

### Changes
- Use a single SQL server in docker-compose
- Move containers to a smaller java base image
- Maven config to retry on download failure
- Use docker buildkit in CI builds
- Run init-service in ci integration test

### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
