### PR TITLE
[ARTS-627] make init-service use correct site-service API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       PRACTITIONER_SERVICE: "http://practitioner-service:8081"
       ROLE_SERVICE: "http://role-service:8082"
       SITE_SERVICE: "http://site-service:8083"
-      CONFIG_JSON: config-init.json
+      CONFIG_JSON: config.json
       SPRING_PROFILES_ACTIVE: "local"
     depends_on:
       practitioner-service:

--- a/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/model/Site.java
+++ b/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/model/Site.java
@@ -3,6 +3,7 @@ package uk.ac.ox.ndph.mts.init_service.model;
 public class Site implements Entity {
     private String name;
     private String alias;
+    private String siteType;
 
     public String getName() {
         return name;
@@ -20,8 +21,17 @@ public class Site implements Entity {
         this.alias = alias;
     }
 
+    public String getSiteType() {
+        return siteType;
+    }
+
+    public void setSiteType(String siteType) {
+        this.siteType = siteType;
+    }
+
     @Override
     public String toString() {
-        return String.format("Site{name='%s', alias='%s'}", name, alias);
+        return String.format("Site{name='%s', alias='%s', type='%s'}", name, alias, siteType);
     }
+
 }

--- a/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/service/ServiceInvoker.java
+++ b/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/service/ServiceInvoker.java
@@ -41,7 +41,8 @@ public abstract class ServiceInvoker {
                     .block();
 
         } catch (Exception e) {
-            LOGGER.info("FAILURE connecting to dependent service {} {}", uri, e.getMessage());
+            LOGGER.warn("FAILURE connecting to dependent service {} {}", uri, e.getMessage());
+            LOGGER.warn("Exception", e);
             throw new DependentServiceException("FAILURE connecting to " + uri);
         }
     }

--- a/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/service/TrialService.java
+++ b/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/service/TrialService.java
@@ -46,6 +46,7 @@ public class TrialService {
 
     @PostConstruct
     public void init() throws InvalidConfigException {
+        LOGGER.info("Loading config: {}", config);
         this.trial = createTrialFromGitRepo(config);
         LOGGER.info("Trial : {}", this.trial);
     }

--- a/init-service/src/main/resources/application.properties
+++ b/init-service/src/main/resources/application.properties
@@ -4,10 +4,11 @@ spring.hateoas.use-hal-as-default-json-media-type=false
 logging.level.uk.ac.ox.ndph.mts.init_service=info
 #logging.level.org.springframework.security=DEBUG
 
-role.service=http://localhost:82
-site.service=http://localhost:83
-practitioner.service=http://localhost:80
-config.json=config-init-bootstrap-roles.json
+# normally get these from the config service, this is for local run only
+role.service=http://localhost:8082
+site.service=http://localhost:8083
+practitioner.service=http://localhost:8081
+config.json=config.json
 
 site.service.endpoint.create=/sites
 role.service.endpoint.create=/roles

--- a/init-service/src/test/java/uk/ac/ox/ndph/mts/init_service/service/SiteServiceTest.java
+++ b/init-service/src/test/java/uk/ac/ox/ndph/mts/init_service/service/SiteServiceTest.java
@@ -21,6 +21,10 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+/*
+ * TODO this test is meaningless because it defines a mock site-service API that does not match the site-service.
+ *  May as well remove it.
+ */
 @ExtendWith(MockitoExtension.class)
 class SiteServiceTest {
 


### PR DESCRIPTION
## Description
* Update API client to site-service
* Added extra logging in init-service to make diagnosing problems easier
* Added updates to get correct configuration file in local & local-docker environments

### Changes
- [ARTS-627] - init-service failing - this PR fixes the interface to the site-service - other random fails seen

### Checklist:

- [X] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [X] I have included a short-meaningful title, description and changes for this PR


[ARTS-627]: https://ndph-arts.atlassian.net/browse/ARTS-627