### PR TITLE
[ARTS-353] add azure credentials to api tests

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Run API Tests
         env:
           BASE_URL: http://localhost
+          AZURE_CLIENT_ID: f352ce15-0142-4dfa-8e18-801ee6391557
+          AZURE_TENANT_ID: 5d23383f-2acb-448e-8353-4b4573b82276
+          AZURE_CLIENT_SECRET: ${{ secrets.CI_CLIENT_SECRET }}
         run: |
           npm run --prefix api-tests api-test-ci
           docker-compose down

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -74,6 +74,7 @@ jobs:
           PROFILE: dev
           SAPASSWORD: $(openssl rand -base64 12)
           GITHUB_SHA: ${{github.sha}}
+          INIT_SERVICE_IDENTITY: 1b8d9098-8c21-452b-b359-430b78cb642d
         run: |
           ./.ci/docker/check-docker-compose-services.sh
       - name: Run API Tests

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run API Tests
         env:
           BASE_URL: http://localhost
-          AZURE_CLIENT_ID: f352ce15-0142-4dfa-8e18-801ee6391557
+          AZURE_CLIENT_ID: a2171b8b-4e97-4523-933a-dc18ef7ef1fe
           AZURE_TENANT_ID: 5d23383f-2acb-448e-8353-4b4573b82276
           AZURE_CLIENT_SECRET: ${{ secrets.CI_CLIENT_SECRET }}
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: "http://discovery-server:8761/eureka/"
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
-      INIT-SERVICE_IDENTITY: "1b8d9098-8c21-452b-b359-430b78cb642d"
+      INIT-SERVICE_IDENTITY: ${INIT_SERVICE_IDENTITY}
     healthcheck:
       test: curl http://localhost:8081
       interval: 10s
@@ -51,7 +51,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: "http://discovery-server:8761/eureka/"
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
-      INIT-SERVICE_IDENTITY: "1b8d9098-8c21-452b-b359-430b78cb642d"
+      INIT-SERVICE_IDENTITY: ${INIT_SERVICE_IDENTITY}
     healthcheck:
       test: curl http://localhost:8082
       interval: 10s
@@ -77,7 +77,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: "http://discovery-server:8761/eureka/"
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
-      INIT-SERVICE_IDENTITY: "1b8d9098-8c21-452b-b359-430b78cb642d"
+      INIT-SERVICE_IDENTITY: ${INIT_SERVICE_IDENTITY}
     healthcheck:
       test: curl http://localhost:8083
       interval: 10s
@@ -107,7 +107,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: "http://discovery-server:8761/eureka/"
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
-      INIT-SERVICE_IDENTITY: "1b8d9098-8c21-452b-b359-430b78cb642d"
+      INIT-SERVICE_IDENTITY: ${INIT_SERVICE_IDENTITY}
     deploy:
       restart_policy:
           condition: none

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: "http://discovery-server:8761/eureka/"
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
+      INIT-SERVICE_IDENTITY: "1b8d9098-8c21-452b-b359-430b78cb642d"
     healthcheck:
       test: curl http://localhost:8081
       interval: 10s
@@ -50,6 +51,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: "http://discovery-server:8761/eureka/"
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
+      INIT-SERVICE_IDENTITY: "1b8d9098-8c21-452b-b359-430b78cb642d"
     healthcheck:
       test: curl http://localhost:8082
       interval: 10s
@@ -75,6 +77,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: "http://discovery-server:8761/eureka/"
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
+      INIT-SERVICE_IDENTITY: "1b8d9098-8c21-452b-b359-430b78cb642d"
     healthcheck:
       test: curl http://localhost:8083
       interval: 10s
@@ -104,6 +107,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: "http://discovery-server:8761/eureka/"
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
+      INIT-SERVICE_IDENTITY: "1b8d9098-8c21-452b-b359-430b78cb642d"
     deploy:
       restart_policy:
           condition: none


### PR DESCRIPTION
## Description
Add azure credentials when running Api Tests

### Changes
- [ARTS-353] - Add azure credentials when running Api Tests. Those credentials will be used by the init-service to retrieve the token and being able to access other services with it.

### Checklist:

- [x] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-353]: https://ndph-arts.atlassian.net/browse/ARTS-353