### PR TITLE
[ARTS-353] Workaround for init authentication

### DIFF
--- a/.ci/docker/check-docker-compose-services.sh
+++ b/.ci/docker/check-docker-compose-services.sh
@@ -36,19 +36,3 @@ while ! is_healthy role-service; do sleep 10; done
 while ! is_healthy practitioner-service; do sleep 10; done
 
 echo "Services started."
-
-echo "Running init-service..."
-set +o errexit # the run might fail and we'd like to continue the script
-docker-compose run --no-deps init-service
-run_exit_code=$?
-set -o errexit
-
-# check the run command exit code
-if [ $run_exit_code -eq 0 ]
-then
-  echo "init-service completed successfully."
-  exit 0
-else
-  echo "init-service failure!" >&2
-  exit 1
-fi

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -74,7 +74,6 @@ jobs:
           PROFILE: dev
           SAPASSWORD: $(openssl rand -base64 12)
           GITHUB_SHA: ${{github.sha}}
-          INIT_SERVICE_IDENTITY: 1b8d9098-8c21-452b-b359-430b78cb642d
           INIT_SERVICE_ACCOUNT_OBJECTID: e6fd67af-ef25-4a4b-af7c-0ed8a7bd40cf
           MTS_AZURE_APP_CLIENT_ID: f352ce15-0142-4dfa-8e18-801ee6391557
           AZURE_CLIENT_ID: a2171b8b-4e97-4523-933a-dc18ef7ef1fe

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -75,22 +75,34 @@ jobs:
           SAPASSWORD: $(openssl rand -base64 12)
           GITHUB_SHA: ${{github.sha}}
           INIT_SERVICE_IDENTITY: 1b8d9098-8c21-452b-b359-430b78cb642d
-          AZURE_AAD_CLIENT_ID: f352ce15-0142-4dfa-8e18-801ee6391557
+          INIT_SERVICE_ACCOUNT_OBJECTID: e6fd67af-ef25-4a4b-af7c-0ed8a7bd40cf
+          MTS_AZURE_APP_CLIENT_ID: f352ce15-0142-4dfa-8e18-801ee6391557
           AZURE_CLIENT_ID: a2171b8b-4e97-4523-933a-dc18ef7ef1fe
           AZURE_TENANT_ID: 5d23383f-2acb-448e-8353-4b4573b82276
           AZURE_CLIENT_SECRET: ${{ secrets.CI_CLIENT_SECRET }}
         run: |
           ./.ci/docker/check-docker-compose-services.sh
+      - name: Run init
+        env:
+          PROFILE: dev
+          GITHUB_SHA: ${{github.sha}}
+          # The following is used by the init-service to generate a token
+          MTS_AZURE_APP_CLIENT_ID: f352ce15-0142-4dfa-8e18-801ee6391557
+          INIT_SERVICE_ACCOUNT_USERNAME: init-service@mtsdevndph.onmicrosoft.com
+          INIT_SERVICE_ACCOUNT_PASSWORD: ${{ secrets.INIT_SERVICE_ACCOUNT_PASSWORD }}
+        run: |
+          set -o nounset
+          set -o errexit
+          docker-compose run --no-deps init-service
       - name: Run API Tests
         env:
           BASE_URL: http://localhost
-          AZURE_AAD_CLIENT_ID: f352ce15-0142-4dfa-8e18-801ee6391557
+          MTS_AZURE_APP_CLIENT_ID: f352ce15-0142-4dfa-8e18-801ee6391557
           AZURE_CLIENT_ID: a2171b8b-4e97-4523-933a-dc18ef7ef1fe
           AZURE_TENANT_ID: 5d23383f-2acb-448e-8353-4b4573b82276
           AZURE_CLIENT_SECRET: ${{ secrets.CI_CLIENT_SECRET }}
         run: |
           npm run --prefix api-tests api-test-ci
-          docker-compose down
       - name: Process API Tests Report
         if: always()
         uses: scacap/action-surefire-report@v1
@@ -100,3 +112,7 @@ jobs:
           report_paths: 'api-tests/api-test-results.xml'
           fail_on_test_failures: true
           fail_if_no_tests: true
+      - name: Stop compose services
+        # this step might be redundant since the job is finishing anyway...
+        run: |
+          docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,9 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: "http://discovery-server:8761/eureka/"
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
-      AZURE_ACTIVEDIRECTORY_CLIENT-ID: ${AZURE_AAD_CLIENT_ID}
-      INIT-SERVICE_IDENTITY: ${INIT_SERVICE_IDENTITY}
+      # This is the id of the client application
+      AZURE_ACTIVEDIRECTORY_CLIENT-ID: ${MTS_AZURE_APP_CLIENT_ID}
+      INIT-SERVICE_IDENTITY: ${INIT_SERVICE_ACCOUNT_OBJECTID}
     healthcheck:
       test: curl http://localhost:8081
       interval: 10s
@@ -53,7 +54,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: "http://discovery-server:8761/eureka/"
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
-      INIT-SERVICE_IDENTITY: ${INIT_SERVICE_IDENTITY}
+      INIT-SERVICE_IDENTITY: ${INIT_SERVICE_ACCOUNT_OBJECTID}
     healthcheck:
       test: curl http://localhost:8082
       interval: 10s
@@ -79,7 +80,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: "http://discovery-server:8761/eureka/"
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
-      INIT-SERVICE_IDENTITY: ${INIT_SERVICE_IDENTITY}
+      INIT-SERVICE_IDENTITY: ${INIT_SERVICE_ACCOUNT_OBJECTID}
     healthcheck:
       test: curl http://localhost:8083
       interval: 10s
@@ -109,10 +110,10 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: "http://discovery-server:8761/eureka/"
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
-      INIT-SERVICE_IDENTITY: ${INIT_SERVICE_IDENTITY}
-      AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}
-      AZURE_TENANT_ID: ${AZURE_TENANT_ID}
-      AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET}
+      # the following 3 entries allow getting a token to send to other services
+      AZURE_USERNAME: ${INIT_SERVICE_ACCOUNT_USERNAME}
+      AZURE_PASSWORD: ${INIT_SERVICE_ACCOUNT_PASSWORD}
+      AZURE_CLIENT_ID: ${MTS_AZURE_APP_CLIENT_ID}
     deploy:
       restart_policy:
           condition: none

--- a/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/config/AzureTokenService.java
+++ b/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/config/AzureTokenService.java
@@ -20,7 +20,6 @@ public class AzureTokenService implements TokenService {
 
         TokenRequestContext trc1 = new TokenRequestContext();
         // Ask for a basic scope that usually all users are able to get.
-//        trc1.addScopes("https://graph.microsoft.com/.default");
         trc1.addScopes("api://mts-dev/default");
 
         return Objects.requireNonNull(tokenCredential.getToken(trc1).block()).getToken();

--- a/practitioner-service/src/main/resources/application-local.yml
+++ b/practitioner-service/src/main/resources/application-local.yml
@@ -11,6 +11,10 @@ role:
 site:
   service:
     uri: http://localhost:8083
+
+init-service:
+  identity: <init-service-identity>
+
 ---
 config:
   name: Practitioner

--- a/practitioner-service/src/main/resources/application-local.yml
+++ b/practitioner-service/src/main/resources/application-local.yml
@@ -11,7 +11,6 @@ role:
 site:
   service:
     uri: http://localhost:8083
-
 init-service:
   identity: <init-service-identity>
 

--- a/practitioner-service/src/test/resources/application.yml
+++ b/practitioner-service/src/test/resources/application.yml
@@ -27,3 +27,5 @@ azure:
   activedirectory:
     client-id: <client-id>
     session-stateless: true
+init-service:
+  identity: <init-service-identity>

--- a/sample-service/src/main/resources/application-local.properties
+++ b/sample-service/src/main/resources/application-local.properties
@@ -2,3 +2,4 @@ azure.keyvault.enabled=false
 azure.keyvault.uri=https://ityekv.vault.azure.net/
 application.message="My app settings value here"
 spring.main.allow-bean-definition-overriding=true
+init-service.identity=<init-service-identity>

--- a/sample-service/src/test/resources/application.yml
+++ b/sample-service/src/test/resources/application.yml
@@ -21,3 +21,5 @@ azure:
   activedirectory:
     client-id: <client-id>
     session-stateless: true
+init-service:
+  identity: <init-service-identity>

--- a/security/src/main/java/uk/ac/ox/ndph/mts/security/authorisation/AuthorisationService.java
+++ b/security/src/main/java/uk/ac/ox/ndph/mts/security/authorisation/AuthorisationService.java
@@ -38,7 +38,7 @@ public class AuthorisationService {
     private final RoleServiceClient roleServiceClient;
     private final SiteServiceClient siteServiceClient;
 
-    @Value("init-service.identity")
+    @Value("${init-service.identity}")
     private String managedIdentity;
 
     @Autowired

--- a/security/src/main/resources/application.yml
+++ b/security/src/main/resources/application.yml
@@ -23,3 +23,5 @@ site:
 spring:
   main:
     allow-bean-definition-overriding: true
+init-service:
+  identity: <init-service-identity>


### PR DESCRIPTION
## Description
Workaround to allow init service to authenticate to the system by using username/password and a new "scope". The actual code changed are small, but we pass different environment variables that make the azure identity library act differently.

### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
