### PR TITLE
[ARTS-609] - Create person API tests to handle authorisation

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -3,14 +3,14 @@ name: Docker build and push
 on:
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
   push:
     # ONLY main branch should be listed below!
-    branches: [ main ]
+    branches: [main]
   # schedule only runs on the main branch
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '1 1 * * *'
+    - cron: "1 1 * * *"
   workflow_dispatch:
 
 jobs:
@@ -18,7 +18,17 @@ jobs:
     name: Build services
     strategy:
       matrix:
-        service_name: [ "sample-service", "practitioner-service", "site-service", "role-service", "init-service", "config-server", "discovery-server", "gateway-server" ]
+        service_name:
+          [
+            "sample-service",
+            "practitioner-service",
+            "site-service",
+            "role-service",
+            "init-service",
+            "config-server",
+            "discovery-server",
+            "gateway-server",
+          ]
     env:
       GHCR: ghcr.io/ndph-arts
     runs-on: ubuntu-latest
@@ -79,6 +89,8 @@ jobs:
           AZURE_CLIENT_ID: a2171b8b-4e97-4523-933a-dc18ef7ef1fe
           AZURE_TENANT_ID: 5d23383f-2acb-448e-8353-4b4573b82276
           AZURE_CLIENT_SECRET: ${{ secrets.CI_CLIENT_SECRET }}
+          AUTOMATION_USER_NAME: test-automation@mtsdevndph.onmicrosoft.com
+          AUTOMATION_USER_PASSWORD: ${{ secrets.AUTOMATION_USER_PASSWORD }}
         run: |
           ./.ci/docker/check-docker-compose-services.sh
       - name: Run init
@@ -95,11 +107,12 @@ jobs:
           docker-compose run --no-deps init-service
       - name: Run API Tests
         env:
-          BASE_URL: http://localhost
+          BASE_URL: http://localhost:8080
           MTS_AZURE_APP_CLIENT_ID: f352ce15-0142-4dfa-8e18-801ee6391557
           AZURE_CLIENT_ID: a2171b8b-4e97-4523-933a-dc18ef7ef1fe
           AZURE_TENANT_ID: 5d23383f-2acb-448e-8353-4b4573b82276
           AZURE_CLIENT_SECRET: ${{ secrets.CI_CLIENT_SECRET }}
+          TEMP_USER_CRED: ${{ secrets.TEMP_USER_CRED }}
         run: |
           npm run --prefix api-tests api-test-ci
       - name: Process API Tests Report
@@ -108,7 +121,7 @@ jobs:
         with:
           check_name: API Tests Report Check
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: 'api-tests/api-test-results.xml'
+          report_paths: "api-tests/api-test-results.xml"
           fail_on_test_failures: true
           fail_if_no_tests: true
       - name: Stop compose services

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -89,8 +89,6 @@ jobs:
           AZURE_CLIENT_ID: a2171b8b-4e97-4523-933a-dc18ef7ef1fe
           AZURE_TENANT_ID: 5d23383f-2acb-448e-8353-4b4573b82276
           AZURE_CLIENT_SECRET: ${{ secrets.CI_CLIENT_SECRET }}
-          AUTOMATION_USER_NAME: test-automation@mtsdevndph.onmicrosoft.com
-          AUTOMATION_USER_PASSWORD: ${{ secrets.AUTOMATION_USER_PASSWORD }}
         run: |
           ./.ci/docker/check-docker-compose-services.sh
       - name: Run init
@@ -112,7 +110,8 @@ jobs:
           AZURE_CLIENT_ID: a2171b8b-4e97-4523-933a-dc18ef7ef1fe
           AZURE_TENANT_ID: 5d23383f-2acb-448e-8353-4b4573b82276
           AZURE_CLIENT_SECRET: ${{ secrets.CI_CLIENT_SECRET }}
-          TEMP_USER_CRED: ${{ secrets.TEMP_USER_CRED }}
+          AUTOMATION_USER_NAME: test-automation@mtsdevndph.onmicrosoft.com
+          AUTOMATION_USER_PASSWORD: ${{ secrets.AUTOMATION_USER_PASSWORD }}
         run: |
           npm run --prefix api-tests api-test-ci
       - name: Process API Tests Report

--- a/api-tests/common/utils.js
+++ b/api-tests/common/utils.js
@@ -1,3 +1,7 @@
+let formData = require('form-data');
+const authUri = 'https://login.microsoftonline.com/5d23383f-2acb-448e-8353-4b4573b82276/oauth2/v2.0/token'
+const fetch = require("node-fetch");
+
 class utils {
 
     getRandomString(length) {
@@ -9,6 +13,34 @@ class utils {
         }
         return result;
     }
+
+    async getTokenId() {
+        let form = new formData();
+        form.append('grant_type', 'password')
+        form.append('client_id', (process.env.MTS_AZURE_APP_CLIENT_ID))
+        form.append('scope', 'openid profile')
+        form.append('username', process.env.AUTOMATION_USER_NAME)
+        form.append('password', process.env.AUTOMATION_USER_PASSWORD)
+        let response = await fetch(authUri, {
+            method: 'POST',
+            body: form
+        })
+
+        let jsonResponse = await response.json();
+        return jsonResponse.id_token;
+    };
+
+    async getHeadersWithAuth() {
+        const tokenId = await this.getTokenId();
+        let headers = {
+            'Authorization': 'Bearer ' + tokenId,
+            'Content-Type': 'application/json',
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Connection': 'keep-alive'
+        };
+        return headers;
+    }
+
 }
 
 module.exports = new utils;

--- a/api-tests/package-lock.json
+++ b/api-tests/package-lock.json
@@ -344,9 +344,9 @@
       "dev": true
     },
     "form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -636,16 +636,16 @@
       "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA=="
     },
     "mime-db": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
     },
     "mime-types": {
-      "version": "2.1.28",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+      "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
       "requires": {
-        "mime-db": "1.45.0"
+        "mime-db": "1.46.0"
       }
     },
     "mimic-fn": {
@@ -863,6 +863,11 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
       "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -1098,6 +1103,18 @@
         "qs": "^6.9.4",
         "readable-stream": "^3.6.0",
         "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "supertest": {

--- a/api-tests/package.json
+++ b/api-tests/package.json
@@ -18,10 +18,12 @@
   },
   "dependencies": {
     "dotenv": "^8.2.0",
-    "http-status-codes": "^2.1.4",
-    "superagent": ">=3.7.0",
     "extend": ">=3.0.2",
+    "form-data": "^4.0.0",
+    "http-status-codes": "^2.1.4",
     "mem": ">=4.0.0",
-    "qs": ">=6.0.4"
+    "node-fetch": "^2.6.1",
+    "qs": ">=6.0.4",
+    "superagent": ">=3.7.0"
   }
 }

--- a/api-tests/specs/createTrialSite/createNewTrialSite.js
+++ b/api-tests/specs/createTrialSite/createNewTrialSite.js
@@ -1,6 +1,6 @@
 const requests = require('../../data/createTrialSite/createNewTrialSite')
 const conf = require('../../config/conf')
-const endpointUri = ':8080/api/sites';
+const endpointUri = '/api/sites';
 let ccoParentSiteId;
 let rccParentSiteId;
 let countryParentSiteId;

--- a/api-tests/specs/practitioner-service/createperson.js
+++ b/api-tests/specs/practitioner-service/createperson.js
@@ -1,47 +1,93 @@
 const requests = require('../../data/practitioner-service/createperson')
 const conf = require('../../config/conf')
-const endpointUri = ':8080/api/practitioner';
+const utils = require('../../common/utils')
+const fetch = require("node-fetch");
+const { expect } = require('chai');
+const endpointUri = '/api/practitioner';
+
 
 describe('As a user with Create Person permission, I want to have my create person request validated by the system, So that I cannot create an invalid person', function () {
 
     it('When I submit an API request to create a Person with a value for all mandatory fields and no fields exceed their specified maximum length, Then a new Person record is persisted in the system with a unique identifier And I receive a success acknowledgement', async () => {
-        const response = await baseRequest.post(endpointUri).send(requests.validPerson);
-        expect(response.text).to.contain("id")
-        expect(response.status).to.equal(HttpStatus.CREATED)
+        const headers = await utils.getHeadersWithAuth()
+        let fetchResponse = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers,
+            method: 'POST',
+            body: JSON.stringify(requests.validPerson),
+        })
+        let response = await fetchResponse.json()
+        expect(fetchResponse.status).to.equal(HttpStatus.CREATED);
+        expect(response).to.have.property('id');
     });
 
     it('When I submit an API request to create a Person with missing non-mandatory prefix field, Then a new Person record is persisted in the system with a unique identifier And I receive a success acknowledgement', async () => {
-        const response = await baseRequest.post(endpointUri).send(requests.missingPrefix);
-        expect(response.text).to.contain("id")
-        expect(response.status).to.equal(HttpStatus.CREATED)
+        const headers = await utils.getHeadersWithAuth()
+        let fetchResponse = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers,
+            method: 'POST',
+            body: JSON.stringify(requests.missingPrefix),
+        })
+        const response = await fetchResponse.json();
+        expect(fetchResponse.status).to.equal(HttpStatus.CREATED);
+        expect(response).to.have.property('id');
     });
 
     it('When I submit an API request to create a Person with missing non-mandatory givenName field, Then a new Person record is persisted in the system with a unique identifier And I receive a success acknowledgement', async () => {
-        const response = await baseRequest.post(endpointUri).send(requests.missingGivenName);
-        expect(response.text).to.contain("id")
-        expect(response.status).to.equal(HttpStatus.CREATED)
+        const headers = await utils.getHeadersWithAuth()
+        let fetchResponse = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers,
+            method: 'POST',
+            body: JSON.stringify(requests.missingGivenName),
+        })
+        const response = await fetchResponse.json();
+        expect(fetchResponse.status).to.equal(HttpStatus.CREATED);
+        expect(response).to.have.property('id');
     });
 
     it('When I submit an API request to create a Person with missing manadatory familyName field, Then a new Person record is not created And I receive an error notification', async () => {
-        const response = await baseRequest.post(endpointUri).send(requests.missingfamilyName);
-        expect(response.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
-        expect(response.text).to.contain("argument Family Name failed validation")
+        const headers = await utils.getHeadersWithAuth()
+        let fetchResponse = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers,
+            method: 'POST',
+            body: JSON.stringify(requests.missingfamilyName),
+        })
+        const response = await fetchResponse.json()
+        expect(fetchResponse.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY);
+        expect(response.message).to.eql('argument Family Name failed validation')
     });
 
     it('When I submit an API request to create a Person with any fields exceeding their specified maximum length, Then a new Person record is not created And I receive an error notification', async () => {
-        const response = await baseRequest.post(endpointUri).send(requests.invalidCharacterLength);
-        expect(response.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
-        expect(response.text).to.contain("argument Family Name failed validation")
+        const headers = await utils.getHeadersWithAuth()
+        let fetchResponse = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers,
+            method: 'POST',
+            body: JSON.stringify(requests.invalidCharacterLength),
+        })
+        const response = await fetchResponse.json();
+        expect(fetchResponse.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY);
+        expect(response.message).to.eql('argument Family Name failed validation')
     });
 
     it('When I submit an API request to create a Person with any fields holding illegal characters, Then a new Person record is not created And I receive an error notification', async () => {
-        const response = await baseRequest.post(endpointUri).send(requests.illegalCharacters);
-        expect(response.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
-        expect(response.text).to.contain("argument Prefix failed validation")
+        const headers = await utils.getHeadersWithAuth()
+        let fetchResponse = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers,
+            method: 'POST',
+            body: JSON.stringify(requests.illegalCharacters),
+        })
+        const response = await fetchResponse.json();
+        expect(fetchResponse.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY);
+        expect(response.message).to.eql('argument Prefix failed validation')
     });
 
     it('When I submit an API request to create a Person with a malformed JSON, Then a new Person record is not created And I receive an error notification', async () => {
-        const response = await baseRequest.post(endpointUri).send(requests.malformedJson);
-        expect(response.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
+        const headers = await utils.getHeadersWithAuth()
+        let fetchResponse = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers,
+            method: 'POST',
+            body: JSON.stringify(requests.malformedJson),
+        })
+        const response = await fetchResponse.json();
+        expect(fetchResponse.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY);
     });
 });

--- a/api-tests/specs/role-service/permissions.js
+++ b/api-tests/specs/role-service/permissions.js
@@ -1,6 +1,6 @@
 const requests = require('../../data/role-service/permissions')
 const conf = require('../../config/conf')
-const endpointUri = ':8080/api/roles';
+const endpointUri = '/api/roles';
 
 describe('As a user I want to set permissions for a role so that I can decide what functionality users assigned this role will have in the system', function () {
 

--- a/api-tests/specs/role-service/roleservice.js
+++ b/api-tests/specs/role-service/roleservice.js
@@ -1,6 +1,6 @@
 const requests = require('../../data/role-service/roleservice')
 const conf = require('../../config/conf')
-const endpointUri = ':8080/api/roles';
+const endpointUri = '/api/roles';
 
 describe('As a user I want to create roles so that they can be assigned to persons', function () {
 

--- a/api-tests/specs/zassign-roles/assign-roles.js
+++ b/api-tests/specs/zassign-roles/assign-roles.js
@@ -1,9 +1,11 @@
 const requests = require('../../data/assign-roles/assign-roles')
 const conf = require('../../config/conf')
-const sitesEndpointUri = ':8080/api/sites';
-const rolesEndpointUri = ':8080/api/roles';
-const practitionerEndpointUri = ':8080/api/practitioner'
-let assignRoleEndpointUri = ':8080/api/practitioner/{personId}/roles'
+const sitesEndpointUri = '/api/sites';
+const rolesEndpointUri = '/api/roles';
+const practitionerEndpointUri = '/api/practitioner'
+let assignRoleEndpointUri = '/api/practitioner/{personId}/roles'
+const utils = require('../../common/utils')
+const fetch = require("node-fetch");
 
 
 describe('As a user with Assign Roles permission I want to assign roles to a user at one or more sites So that I can control what functionality they have at different parts of the site hierarchy', function () {
@@ -17,9 +19,15 @@ describe('As a user with Assign Roles permission I want to assign roles to a use
         parentSiteId = parseParentSiteIdData[0].siteId
 
         //request posted to practitioner end point
-        const personResponse = await baseRequest.post(practitionerEndpointUri).send(requests.createPerson)
-        const capturePersonResponseData = personResponse.text
-        let parsePersonResponseData = JSON.parse(capturePersonResponseData)
+        let headers = await utils.getHeadersWithAuth()
+        let fetchResponse = await fetch(conf.baseUrl + practitionerEndpointUri, {
+            headers: headers,
+            method: 'POST',
+            body: JSON.stringify(requests.createPerson),
+        })
+        let personResponse = await fetchResponse.json();
+        const capturePersonResponseData = personResponse
+        let parsePersonResponseData = capturePersonResponseData
         personId = parsePersonResponseData.id
 
         //request posted to role service endpoint
@@ -32,8 +40,14 @@ describe('As a user with Assign Roles permission I want to assign roles to a use
         let assignRoleJSON = requests.assignRole
         assignRoleJSON.siteId = parentSiteId
         assignRoleJSON.roleId = roleId
+        let headers1 = await utils.getHeadersWithAuth()
         assignRoleEndpointUri = assignRoleEndpointUri.replace("{personId}", personId);
-        const response = await baseRequest.post(assignRoleEndpointUri).send(assignRoleJSON)
-        expect(response.status).to.equal(HttpStatus.CREATED)
+        let fetchResponse1 = await fetch(conf.baseUrl + assignRoleEndpointUri, {
+            headers: headers1,
+            method: 'POST',
+            body: JSON.stringify(assignRoleJSON),
+        })
+
+        expect(fetchResponse1.status).to.equal(HttpStatus.CREATED)
     });
 });


### PR DESCRIPTION
## Description
Code added to fetch token id of a user from azure active directory. The token id is the bearer header used to authorise in creating a person via practitioner services.
The related api tests for create person is updated with the code that fetches the token Id.
I have added a function to the utils file which can be used globally.
The token id parameters are encoded in a json file that are configurable.

### Changes
- ARTS-609 - Create person authorisation
- ARTS-654 - Fetch Token Id from azure active directory

### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR
