### PR TITLE
[ARTS-364] Add Application Insights for logs and metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
 # This dockerfile includes "conditional layers" and best used with DOCKER_BUILDKIT=1.
-
 ARG DEPS_CACHE=project
+ARG BUILDER_IMAGE=maven:3-openjdk-11
+ARG RUNTIME_IMAGE=adoptopenjdk/openjdk11:jre-11.0.10_9-debianslim
+ARG APPINSIGHTS_FILE=applicationinsights-agent-3.0.2.jar
+ARG APPINSIGHTS_URL_PREFIX=https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.0.2
 
-FROM maven:3-openjdk-11 as builder
+
+FROM ${BUILDER_IMAGE} as builder
+ARG APPINSIGHTS_FILE
+ARG APPINSIGHTS_URL_PREFIX
+# downloading in builder to copy the jar and config file together in 1 layer
+RUN wget "${APPINSIGHTS_URL_PREFIX}/${APPINSIGHTS_FILE}" --output-document applicationinsights-agent.jar
 
 # copy parent poms
 COPY ./pom*.xml ./
@@ -41,9 +49,10 @@ ARG SVC
 COPY . ./
 RUN mvn package --projects ${SVC} --batch-mode -q --also-make -Dmaven.wagon.http.retryHandler.count=3
 
-FROM adoptopenjdk/openjdk11:jre-11.0.10_9-debianslim
+FROM ${RUNTIME_IMAGE}
 ARG SVC
 ARG JAR_FILE=${SVC}/target/*.jar
+COPY --from=builder-cached applicationinsights* .
 COPY --from=builder-cached ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","-javaagent:applicationinsights-agent.jar", "-jar","/app.jar"]
 EXPOSE 8080:80

--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -1,0 +1,13 @@
+{
+  "sampling": {
+    "percentage": 100
+  },
+  "instrumentation": {
+    "logging": {
+      "level": "DEBUG"
+    },
+    "micrometer": {
+      "enabled": true
+    }
+  }
+}

--- a/practitioner-service/src/main/resources/bootstrap.yml
+++ b/practitioner-service/src/main/resources/bootstrap.yml
@@ -6,6 +6,7 @@ spring:
       discovery:
         enabled: true
         service-id: CONFIG-SERVER
+      fail-fast: true
 
 eureka:
   client:

--- a/role-service/src/main/resources/bootstrap.yml
+++ b/role-service/src/main/resources/bootstrap.yml
@@ -6,6 +6,7 @@ spring:
       discovery:
         enabled: true
         service-id: CONFIG-SERVER
+      fail-fast: true
 
 eureka:
   client:

--- a/site-service/src/main/resources/bootstrap.yml
+++ b/site-service/src/main/resources/bootstrap.yml
@@ -6,6 +6,7 @@ spring:
       discovery:
         enabled: true
         service-id: CONFIG-SERVER
+      fail-fast: true
 
 eureka:
   client:


### PR DESCRIPTION
## Description
This adds application insights to all services to collect logs and metrics.
This can be merged without waiting for the deployment related PR.

### Changes
- [ARTS-364] Collect logs/metrics
- Add spring cloud config "fail-fast" because if the config isn't available at startup, no point to bring up the/any service.

### Checklist:

- [x] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-364]: https://ndph-arts.atlassian.net/browse/ARTS-364