### PR TITLE
[Fix] Typo in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,9 +99,9 @@ services:
     image: ghcr.io/ndph-arts/init-service:${GITHUB_SHA}
     restart: on-failure
     environment:
-      PRACTITIONER-SERVICE_URI: "http://practitioner-service:8081"
-      ROLE-SERVICE_URI: "http://role-service:8082"
-      SITE-SERVICE_URI: "http://site-service:8083"
+      PRACTITIONER_SERVICE_URI: "http://practitioner-service:8081"
+      ROLE_SERVICE_URI: "http://role-service:8082"
+      SITE_SERVICE_URI: "http://site-service:8083"
       SPRING_PROFILES_ACTIVE: ${PROFILE:-local}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: "http://discovery-server:8761/eureka/"
       SPRING_CLOUD_CONFIG_LABEL: "main"


### PR DESCRIPTION
## Description
Fix of typo in env var name in docker compose.

### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
