### PR TITLE
Optimize docker build

### DIFF
--- a/.ci/docker/check-docker-compose-services.sh
+++ b/.ci/docker/check-docker-compose-services.sh
@@ -25,14 +25,16 @@ is_healthy() {
 docker-compose pull -q
 docker-compose up --no-build -d gateway-server config-server discovery-server
 
+# start it here to save some time
+docker-compose up --no-build -d fhir-api
+
 echo "Waiting for services to become healthy..."
 while ! is_healthy discovery-server; do sleep 10; done
 while ! is_healthy config-server; do sleep 10; done
 while ! is_healthy gateway-server; do sleep 10; done
 
 docker-compose up --no-build -d practitioner-service site-service role-service
-while ! is_healthy site-service; do sleep 10; done
-while ! is_healthy role-service; do sleep 10; done
-while ! is_healthy practitioner-service; do sleep 10; done
+
+sleep 10
 
 echo "Services started."

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -6,7 +6,7 @@ on:
       - "**.md"
   push:
     # ONLY main branch should be listed below!
-    branches: [main]
+    branches: [ main ]
   # schedule only runs on the main branch
   schedule:
     # * is a special character in YAML so you have to quote this string
@@ -20,14 +20,14 @@ jobs:
       matrix:
         service_name:
           [
-            "sample-service",
-            "practitioner-service",
-            "site-service",
-            "role-service",
-            "init-service",
-            "config-server",
-            "discovery-server",
-            "gateway-server",
+              "sample-service",
+              "practitioner-service",
+              "site-service",
+              "role-service",
+              "init-service",
+              "config-server",
+              "discovery-server",
+              "gateway-server",
           ]
     env:
       GHCR: ghcr.io/ndph-arts
@@ -42,17 +42,67 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_LOGIN }}
-      - name: Build & publish runtime image
+
+      - name: Check docker images
+        id: check_docker_images
+        run: |
+          set -o nounset
+          RUNTIME_TAG=$GHCR/${{ matrix.service_name }}:${{ github.sha }}
+          echo "::set-output name=runtime_tag::${RUNTIME_TAG}"
+
+          # Hashing most files that can change the full dependency stage and using as a tag.
+          DEPS_TAG=$GHCR/mts-services-deps-cache-full:${{ hashFiles('Dockerfile', '**/pom*.xml') }}
+          echo "::set-output name=deps_tag::${DEPS_TAG}"
+
+          echo "Checking if the runtime image exists..."
+          # We might have failures, but shouldn't exit.
+          set +o errexit
+          docker manifest inspect $RUNTIME_TAG > /dev/null
+          RUNTIME_VALUE=$?
+          set -o errexit
+          if [ ${RUNTIME_VALUE} -eq 0 ]
+          then
+            echo "Runtime image already exists for this commit SHA, no need to rebuild it."
+            echo "::set-output name=runtime_exists::true"
+            exit 0
+          fi
+
+          set +o errexit
+          docker pull $DEPS_TAG
+          DEPS_VALUE=$?
+          set -o errexit
+          if [ ${DEPS_VALUE} -eq 0 ]
+          then
+            echo "Deps stage exists with the required tag, no need to rebuild it."
+            echo "::set-output name=deps_exists::true"
+          fi
+
+      - name: Build & publish deps stage
+        # If both images don't exist we need to build the deps (since we'll build the runtime image in the next step)
+        if: ${{ steps.check_docker_images.outputs.runtime_exists != 'true' && steps.check_docker_images.outputs.deps_exists != 'true' }}
         env:
           DOCKER_BUILDKIT: 1
         run: |
-          set -o errexit
           set -o nounset
+          set -o errexit
+          # Using stage deps-cache-full to share in all services.
+          docker build --target deps-cache-full --cache-from ${{ steps.check_docker_images.outputs.deps_tag }} \
+            --tag  ${{ steps.check_docker_images.outputs.deps_tag }} --build-arg BUILDKIT_INLINE_CACHE=1 .
+          docker push ${{ steps.check_docker_images.outputs.deps_tag }}
 
-          TAG=$GHCR/${{ matrix.service_name }}:${{ github.sha }}
+      - name: Build & publish runtime image
+        if: ${{ steps.check_docker_images.outputs.runtime_exists != 'true' }}
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          set -o nounset
+          set -o errexit
+          docker build --build-arg SVC="${{ matrix.service_name }}" --build-arg DEPS_CACHE=full \
+            --cache-from ${{ steps.check_docker_images.outputs.deps_tag }} \
+            --cache-from ${{ steps.check_docker_images.outputs.runtime_tag }} \
+            --tag ${{ steps.check_docker_images.outputs.runtime_tag }} --build-arg BUILDKIT_INLINE_CACHE=1 .
+          docker push ${{ steps.check_docker_images.outputs.runtime_tag }}
 
-          docker build --build-arg SVC="${{ matrix.service_name }}" -t $TAG .
-          docker push $TAG
       - name: Publish named image
         # The way to run this only on "merge" to main branch is to catch the "push" event into it (and schedule).
         if: github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'push')
@@ -62,12 +112,8 @@ jobs:
         run: |
           set -o errexit
           set -o nounset
-
-          FROM_TAG=$GHCR/${{ matrix.service_name }}:${{ github.sha }}
           TO_TAG=$GHCR/${{ matrix.service_name }}:$TAG
-
-          # assume the step before created the image with the sha tag
-          docker tag $FROM_TAG $TO_TAG
+          docker tag ${{ steps.check_docker_images.outputs.runtime_tag }} $TO_TAG
           docker push $TO_TAG
 
   buildall:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
 # This dockerfile includes "conditional layers" and best used with DOCKER_BUILDKIT=1.
 ARG DEPS_CACHE=project
-ARG BUILDER_IMAGE=maven:3-openjdk-11
+ARG BUILDER_IMAGE=maven:3-openjdk-11-slim
 ARG RUNTIME_IMAGE=adoptopenjdk/openjdk11:jre-11.0.10_9-debianslim
 ARG APPINSIGHTS_FILE=applicationinsights-agent-3.0.2.jar
 ARG APPINSIGHTS_URL_PREFIX=https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.0.2
 
-
 FROM ${BUILDER_IMAGE} as builder
 ARG APPINSIGHTS_FILE
 ARG APPINSIGHTS_URL_PREFIX
-# downloading in builder to copy the jar and config file together in 1 layer
-RUN wget "${APPINSIGHTS_URL_PREFIX}/${APPINSIGHTS_FILE}" --output-document applicationinsights-agent.jar
+# downloading first since it isn't updated too much (hence cached)
+RUN curl -L "${APPINSIGHTS_URL_PREFIX}/${APPINSIGHTS_FILE}" --output applicationinsights-agent.jar
 
+# This section copies the requirements to build our project, but also considers layer caching.
+# Start by copying things that are less likely to be updated and make our cache last longer.
 # copy parent poms
 COPY ./pom*.xml ./
 
@@ -38,8 +39,8 @@ ARG SVC
 RUN mvn dependency:go-offline --projects ${SVC} --batch-mode -q --also-make -Dmaven.wagon.http.retryHandler.count=3
 
 FROM builder as deps-cache-full
-# cache ALL dependencies as a layer to be used in other builds while POMs don't change.
-# the layer produced could be used for all projects, good for local running, not ci.
+# Cache ALL dependencies as a layer to be used in other builds while POMs don't change.
+# This stage can be used for all projects - used in the CI, local is also possible.
 RUN mvn dependency:go-offline --batch-mode -q -Dmaven.wagon.http.retryHandler.count=3
 
 FROM deps-cache-${DEPS_CACHE} as builder-cached
@@ -49,10 +50,14 @@ ARG SVC
 COPY . ./
 RUN mvn package --projects ${SVC} --batch-mode -q --also-make -Dmaven.wagon.http.retryHandler.count=3
 
-FROM ${RUNTIME_IMAGE}
+# This stage allows us to prepare all the files we need for runtime and copy in 1 layer
+FROM scratch as pre-runtime
 ARG SVC
 ARG JAR_FILE=${SVC}/target/*.jar
-COPY --from=builder-cached applicationinsights* .
-COPY --from=builder-cached ${JAR_FILE} app.jar
+COPY --from=builder-cached applicationinsights* ./runtime/
+COPY --from=builder-cached ${JAR_FILE} ./runtime/app.jar
+
+FROM ${RUNTIME_IMAGE}
+COPY --from=pre-runtime ./runtime/* ./
 ENTRYPOINT ["java","-javaagent:applicationinsights-agent.jar", "-jar","/app.jar"]
 EXPOSE 8080:80


### PR DESCRIPTION
## Description
Optimize the docker builds to reduce time.

### Changes
- Checks if the runtime image already exists with the right tag before building it.
- Reuse the maven dependencies across services and builds if it hasn't change (cached as a layer)
- Start using a slim base for the runtime image (~100MB less)
- Stop waiting for the business services in the CI since that better represent a real startup of the system on the cloud (init is able to retry if the service isn't online yet).

### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
