### PR TITLE
[ARTS-793] - Increasing default search result set from FHIR

### DIFF
--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
@@ -18,7 +18,7 @@ import java.util.List;
 @Component
 public class FhirContextWrapper {
     private final FhirContext fhirContext;
-    private final int RESULT_COUNT = 50;
+    private final int RESULTS = 50;
 
     /**
      * constructor
@@ -87,7 +87,7 @@ public class FhirContextWrapper {
         return fhirContext.newRestfulGenericClient(uri)
                 .search()
                 .forResource(resourceClass)
-                .count(RESULT_COUNT)
+                .count(RESULTS)
                 .returnBundle(Bundle.class);
     }
 

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
@@ -21,7 +21,7 @@ public class FhirContextWrapper {
     private final FhirContext fhirContext;
 
     @Value("${fhir.resultCount:50}")
-    private String result;
+    private String resultCount;
 
     /**
      * constructor
@@ -90,7 +90,7 @@ public class FhirContextWrapper {
         return fhirContext.newRestfulGenericClient(uri)
                 .search()
                 .forResource(resourceClass)
-                .count(Integer.parseInt(result))
+                .count(Integer.parseInt(resultCount))
                 .returnBundle(Bundle.class);
     }
 

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
@@ -18,6 +18,7 @@ import java.util.List;
 @Component
 public class FhirContextWrapper {
     private final FhirContext fhirContext;
+    private final int RESULT_COUNT = 50;
 
     /**
      * constructor
@@ -86,6 +87,7 @@ public class FhirContextWrapper {
         return fhirContext.newRestfulGenericClient(uri)
                 .search()
                 .forResource(resourceClass)
+                .count(RESULT_COUNT)
                 .returnBundle(Bundle.class);
     }
 

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/repository/FhirContextWrapper.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.util.BundleUtil;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -18,7 +19,9 @@ import java.util.List;
 @Component
 public class FhirContextWrapper {
     private final FhirContext fhirContext;
-    private final int RESULTS = 50;
+
+    @Value("${fhir.resultCount:50}")
+    private String result;
 
     /**
      * constructor
@@ -87,7 +90,7 @@ public class FhirContextWrapper {
         return fhirContext.newRestfulGenericClient(uri)
                 .search()
                 .forResource(resourceClass)
-                .count(RESULTS)
+                .count(Integer.parseInt(result))
                 .returnBundle(Bundle.class);
     }
 

--- a/site-service/src/main/resources/application-local.yml
+++ b/site-service/src/main/resources/application-local.yml
@@ -5,6 +5,7 @@ server:
     include-message: always
 fhir:
   uri: http://localhost:8099
+  resultCount: 50
 # trial site config - this is the default for local testing, with CCO/REGION/COUNTRY/LCC
 site:
   name: Organization


### PR DESCRIPTION
Increasing result set size form FHIR to 50

## Description
We are currently only returning a max of 10 results from FHIR. Increasing result set size form FHIR to 50.

This change is linked to the config repo changes and therefore API tests will fail until the linked PR is merged into main - https://github.com/NDPH-ARTS/mts-trial-deployment-config/pull/87/files

### Changes
- [ARTS-793] - Increasing result set size form FHIR to 50

### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR


[ARTS-793]: https://ndph-arts.atlassian.net/browse/ARTS-793