### PR TITLE
[ARTS-207] - API tests covering address fields at sites endpoint

### DIFF
--- a/api-tests/common/utils.js
+++ b/api-tests/common/utils.js
@@ -1,3 +1,10 @@
+/**
+ * Utils class class covering functions to use across the api tests
+ * 
+ * Author Sameera Purini
+ * 
+ */
+
 let formData = require('form-data');
 const authUri = 'https://login.microsoftonline.com/5d23383f-2acb-448e-8353-4b4573b82276/oauth2/v2.0/token'
 const fetch = require("node-fetch");

--- a/api-tests/common/utils.js
+++ b/api-tests/common/utils.js
@@ -17,10 +17,10 @@ class utils {
     async getTokenId() {
         let form = new formData();
         form.append('grant_type', 'password')
-        form.append('client_id', (process.env.MTS_AZURE_APP_CLIENT_ID))
+        form.append('client_id', 'f352ce15-0142-4dfa-8e18-801ee6391557')
         form.append('scope', 'openid profile')
-        form.append('username', process.env.AUTOMATION_USER_NAME)
-        form.append('password', process.env.AUTOMATION_USER_PASSWORD)
+        form.append('username', 'test-automation@mtsdevndph.onmicrosoft.com')
+        form.append('password', 'kjrUB5$_S.19dTTR')
         let response = await fetch(authUri, {
             method: 'POST',
             body: form

--- a/api-tests/common/utils.js
+++ b/api-tests/common/utils.js
@@ -24,10 +24,10 @@ class utils {
     async getTokenId() {
         let form = new formData();
         form.append('grant_type', 'password')
-        form.append('client_id', 'f352ce15-0142-4dfa-8e18-801ee6391557')
+        form.append('client_id', process.env.MTS_AZURE_APP_CLIENT_ID)
         form.append('scope', 'openid profile')
-        form.append('username', 'test-automation@mtsdevndph.onmicrosoft.com')
-        form.append('password', 'kjrUB5$_S.19dTTR')
+        form.append('username', process.env.AUTOMATION_USER_NAME)
+        form.append('password', process.env.AUTOMATION_USER_PASSWORD)
         let response = await fetch(authUri, {
             method: 'POST',
             body: form

--- a/api-tests/data/assign-roles/assign-roles.js
+++ b/api-tests/data/assign-roles/assign-roles.js
@@ -1,3 +1,10 @@
+/**
+ * Assign roles class file with data to run the assign roles test scenarios
+ * 
+ * Author Sameera Purini
+ * 
+ */
+
 const utils = require('../../common/utils')
 
 const roleWithPermissions = {

--- a/api-tests/data/createTrialSite/createNewTrialSite.js
+++ b/api-tests/data/createTrialSite/createNewTrialSite.js
@@ -27,8 +27,19 @@ const validSiteLCC = {
     "name": utils.getRandomString(5),
     "alias": utils.getRandomString(5),
     "parentSiteId": "",
-    "siteType": "LCC"
+    "siteType": "LCC",
+    "address": {
+        "address1": "University of Oxford ",
+        "address2": "Richard Doll Building",
+        "address3": "Old Road Campus",
+        "address4": "Headington",
+        "address5": "",
+        "city": "Oxford",
+        "country": "United Kingdom",
+        "postcode": "OX3 7LF"
+    }
 }
+
 
 //parentSiteId - rccParentSiteId
 const missingName = {

--- a/api-tests/data/createTrialSite/sitesAddress.js
+++ b/api-tests/data/createTrialSite/sitesAddress.js
@@ -1,3 +1,4 @@
+// author - Sameera Purini
 const utils = require('../../common/utils')
 
 const InvalidRegion = {

--- a/api-tests/data/createTrialSite/sitesAddress.js
+++ b/api-tests/data/createTrialSite/sitesAddress.js
@@ -1,4 +1,9 @@
-// author - Sameera Purini
+/**
+ * Site Address data covering assign roles regression test scenarios
+ * 
+ * Author Sameera Purini
+ * 
+ */
 const utils = require('../../common/utils')
 
 const InvalidRegion = {

--- a/api-tests/data/createTrialSite/sitesAddress.js
+++ b/api-tests/data/createTrialSite/sitesAddress.js
@@ -1,0 +1,85 @@
+const utils = require('../../common/utils')
+
+const InvalidRegion = {
+    "name": utils.getRandomString(4),
+    "alias": utils.getRandomString(4),
+    "parentSiteId": "",
+    "siteType": "REGION",
+    "address": {
+        "address1": "address1",
+        "address2": "address2",
+        "address3": "address3",
+        "address4": "address4",
+        "address5": "address5",
+        "city": "city",
+        "country": "country",
+        "postcode": "postcode",
+    }
+}
+
+const ValidRegion = {
+    "name": utils.getRandomString(4),
+    "alias": utils.getRandomString(4),
+    "parentSiteId": "",
+    "siteType": "REGION",
+    "address": null
+}
+
+const ValidCountry = {
+    "name": utils.getRandomString(4),
+    "alias": utils.getRandomString(4),
+    "parentSiteId": "",
+    "siteType": "COUNTRY",
+    "address": null
+}
+
+const LCCWithAddress = {
+    "name": utils.getRandomString(4),
+    "alias": utils.getRandomString(4),
+    "parentSiteId": "",
+    "siteType": "LCC",
+    "address": {
+        "address1": "University of Oxford",
+        "address2": "Richard Doll Building",
+        "address3": "Old Road Campus",
+        "address4": "",
+        "address5": "Headington",
+        "city": "Oxford",
+        "country": "",
+        "postcode": "OX3 7LF",
+    }
+}
+
+const LCCWithOutAddress = {
+    "name": utils.getRandomString(4),
+    "alias": utils.getRandomString(4),
+    "parentSiteId": "",
+    "siteType": "LCC",
+    "address": null
+}
+
+const emptyAddressFields = {
+    "name": utils.getRandomString(4),
+    "alias": utils.getRandomString(4),
+    "parentSiteId": "",
+    "siteType": "LCC",
+    "address": {
+        "address1": "",
+        "address2": "",
+        "address3": "",
+        "address4": "",
+        "address5": "",
+        "city": "",
+        "country": "",
+        "postcode": "",
+    }
+}
+
+module.exports = {
+    InvalidRegion,
+    ValidRegion,
+    ValidCountry,
+    LCCWithAddress,
+    LCCWithOutAddress,
+    emptyAddressFields
+}

--- a/api-tests/data/role-service/permissions.js
+++ b/api-tests/data/role-service/permissions.js
@@ -1,3 +1,10 @@
+/**
+ * Permissions data covering permissions egression test scenarios
+ * 
+ * Author Sameera Purini
+ * 
+ */
+
 const utils = require('../../common/utils')
 
 const assignPermission = {

--- a/api-tests/data/role-service/roleservice.js
+++ b/api-tests/data/role-service/roleservice.js
@@ -1,3 +1,10 @@
+/**
+ * Role services data covering roles egression test scenarios
+ * 
+ * Author Sameera Purini
+ * 
+ */
+
 const utils = require('../../common/utils')
 
 const validRole = {

--- a/api-tests/specs/createTrialSite/sitesAddress.js
+++ b/api-tests/specs/createTrialSite/sitesAddress.js
@@ -1,3 +1,4 @@
+// author - Sameera Purini
 const requests = require('../../data/createTrialSite/sitesAddress')
 const conf = require('../../config/conf')
 const endpointUri = '/api/sites';

--- a/api-tests/specs/createTrialSite/sitesAddress.js
+++ b/api-tests/specs/createTrialSite/sitesAddress.js
@@ -16,7 +16,7 @@ let countrySiteId;
 
 describe('As a user with Create Trial Sites permission I want to create a trial site with an address where that trial site type requires an address so that I can add a physical address to organisational trial sites when required in my site structure', function () {
 
-    it.only('User with Create Trial Sites permission is logged in to a Trial Instance with at least one Trial Site Type that requires an address to check if the required address fields have been defined', async () => {
+    it('User with Create Trial Sites permission is logged in to a Trial Instance with at least one Trial Site Type that requires an address to check if the required address fields have been defined', async () => {
         const headers = await utils.getHeadersWithAuth()
         let fetchResponse = await fetch(conf.baseUrl + endpointUri, {
             headers: headers,
@@ -29,7 +29,7 @@ describe('As a user with Create Trial Sites permission I want to create a trial 
         expect(CCOData).to.contain({ "address1": "address1", "address2": "address2", "address3": "address3", "address4": "address4", "address5": "address5", "city": "city", "country": "country", "postcode": "postcode" })
     });
 
-    it.only('User submits an API request to create a trial site with address fields in a region where address is not configured then the user is shown an error message', async () => {
+    it('User submits an API request to create a trial site with address fields in a region where address is not configured then the user is shown an error message', async () => {
         let regionParentSiteId = requests.InvalidRegion;
         regionParentSiteId.parentSiteId = ccoParentSiteId
         const headers1 = await utils.getHeadersWithAuth()
@@ -43,7 +43,7 @@ describe('As a user with Create Trial Sites permission I want to create a trial 
         expect(regionResponse.message).to.eql('argument Cannot have Address failed validation')
     });
 
-    it.only('User submits an API request to create a region in a trial site with address fields configured as null then the region is created successfully with the generation of an id', async () => {
+    it('User submits an API request to create a region in a trial site with address fields configured as null then the region is created successfully with the generation of an id', async () => {
         let validRegionSiteId = requests.ValidRegion;
         validRegionSiteId.parentSiteId = ccoParentSiteId
         const headers2 = await utils.getHeadersWithAuth()
@@ -58,7 +58,7 @@ describe('As a user with Create Trial Sites permission I want to create a trial 
         expect(fetchResponse2.status).to.equal(HttpStatus.CREATED)
     });
 
-    it.only('User submits an API request to create a country in a trial site with address fields configured as null then the country is created successfully with the generation of an id', async () => {
+    it('User submits an API request to create a country in a trial site with address fields configured as null then the country is created successfully with the generation of an id', async () => {
         let validCountrySiteId = requests.ValidCountry
         validCountrySiteId.parentSiteId = validRegionSite
         const headers3 = await utils.getHeadersWithAuth()
@@ -72,7 +72,7 @@ describe('As a user with Create Trial Sites permission I want to create a trial 
         expect(fetchResponse3.status).to.equal(HttpStatus.CREATED)
     });
 
-    it.only('User submits an API request to create a trial site with an address in LCC then an address is associated with the LCC site in the system and an acknowledgement is returned', async () => {
+    it('User submits an API request to create a trial site with an address in LCC then an address is associated with the LCC site in the system and an acknowledgement is returned', async () => {
         let LCCParentSiteId = requests.LCCWithAddress
         LCCParentSiteId.parentSiteId = countrySiteId
         const headers4 = await utils.getHeadersWithAuth()
@@ -85,7 +85,7 @@ describe('As a user with Create Trial Sites permission I want to create a trial 
         expect(fetchResponse4.status).to.equal(HttpStatus.CREATED)
     });
 
-    it.only('User submits an API request to create a trial site without an address in LCC then an error message is returned', async () => {
+    it('User submits an API request to create a trial site without an address in LCC then an error message is returned', async () => {
         let LCCIdWithoutAddress = requests.LCCWithOutAddress
         LCCIdWithoutAddress.parentSiteId = countrySiteId
         const headers5 = await utils.getHeadersWithAuth()
@@ -99,7 +99,7 @@ describe('As a user with Create Trial Sites permission I want to create a trial 
         expect(LCCWithoutAddressResponse.message).to.eql('argument No Address in payload failed validation')
     });
 
-    it.only('User submits an API request to create a trial site with an address in LCC with no values populated, then an address is not associated with the trial site record and I receive an error notification', async () => {
+    it('User submits an API request to create a trial site with an address in LCC with no values populated, then an address is not associated with the trial site record and I receive an error notification', async () => {
         let EmptyAddressId = requests.emptyAddressFields
         EmptyAddressId.parentSiteId = countrySiteId
         const headers6 = await utils.getHeadersWithAuth()

--- a/api-tests/specs/createTrialSite/sitesAddress.js
+++ b/api-tests/specs/createTrialSite/sitesAddress.js
@@ -1,4 +1,9 @@
-// author - Sameera Purini
+/**
+ * Site address class covering roles regression test scenarios
+ * 
+ * Author Sameera Purini
+ * 
+ */
 const requests = require('../../data/createTrialSite/sitesAddress')
 const conf = require('../../config/conf')
 const endpointUri = '/api/sites';

--- a/api-tests/specs/createTrialSite/sitesAddress.js
+++ b/api-tests/specs/createTrialSite/sitesAddress.js
@@ -1,0 +1,109 @@
+const requests = require('../../data/createTrialSite/sitesAddress')
+const conf = require('../../config/conf')
+const endpointUri = '/api/sites';
+const utils = require('../../common/utils')
+const fetch = require("node-fetch");
+
+let ccoParentSiteId;
+let validRegionSite;
+let countrySiteId;
+
+describe('As a user with Create Trial Sites permission I want to create a trial site with an address where that trial site type requires an address so that I can add a physical address to organisational trial sites when required in my site structure', function () {
+
+    it.only('User with Create Trial Sites permission is logged in to a Trial Instance with at least one Trial Site Type that requires an address to check if the required address fields have been defined', async () => {
+        const headers = await utils.getHeadersWithAuth()
+        let fetchResponse = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers,
+            method: 'GET',
+        })
+
+        let response = await fetchResponse.json();
+        ccoParentSiteId = response[0].siteId
+        CCOData = response[0].address
+        expect(CCOData).to.contain({ "address1": "address1", "address2": "address2", "address3": "address3", "address4": "address4", "address5": "address5", "city": "city", "country": "country", "postcode": "postcode" })
+    });
+
+    it.only('User submits an API request to create a trial site with address fields in a region where address is not configured then the user is shown an error message', async () => {
+        let regionParentSiteId = requests.InvalidRegion;
+        regionParentSiteId.parentSiteId = ccoParentSiteId
+        const headers1 = await utils.getHeadersWithAuth()
+        let fetchResponse1 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers1,
+            method: 'POST',
+            body: JSON.stringify(regionParentSiteId),
+        })
+        let regionResponse = await fetchResponse1.json();
+        expect(regionResponse.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
+        expect(regionResponse.message).to.eql('argument Cannot have Address failed validation')
+    });
+
+    it.only('User submits an API request to create a region in a trial site with address fields configured as null then the region is created successfully with the generation of an id', async () => {
+        let validRegionSiteId = requests.ValidRegion;
+        validRegionSiteId.parentSiteId = ccoParentSiteId
+        const headers2 = await utils.getHeadersWithAuth()
+        let fetchResponse2 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers2,
+            method: 'POST',
+            body: JSON.stringify(validRegionSiteId),
+        })
+        const validRegionSiteResponse = await fetchResponse2.json();
+        console.log('status of the response' + JSON.stringify(validRegionSiteResponse.status))
+        validRegionSite = validRegionSiteResponse.id
+        expect(fetchResponse2.status).to.equal(HttpStatus.CREATED)
+    });
+
+    it.only('User submits an API request to create a country in a trial site with address fields configured as null then the country is created successfully with the generation of an id', async () => {
+        let validCountrySiteId = requests.ValidCountry
+        validCountrySiteId.parentSiteId = validRegionSite
+        const headers3 = await utils.getHeadersWithAuth()
+        let fetchResponse3 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers3,
+            method: 'POST',
+            body: JSON.stringify(validCountrySiteId),
+        })
+        const countrySiteResponse = await fetchResponse3.json();
+        countrySiteId = countrySiteResponse.id
+        expect(fetchResponse3.status).to.equal(HttpStatus.CREATED)
+    });
+
+    it.only('User submits an API request to create a trial site with an address in LCC then an address is associated with the LCC site in the system and an acknowledgement is returned', async () => {
+        let LCCParentSiteId = requests.LCCWithAddress
+        LCCParentSiteId.parentSiteId = countrySiteId
+        const headers4 = await utils.getHeadersWithAuth()
+        let fetchResponse4 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers4,
+            method: 'POST',
+            body: JSON.stringify(LCCParentSiteId),
+        })
+        let LCCResponse = await fetchResponse4.json();
+        expect(fetchResponse4.status).to.equal(HttpStatus.CREATED)
+    });
+
+    it.only('User submits an API request to create a trial site without an address in LCC then an error message is returned', async () => {
+        let LCCIdWithoutAddress = requests.LCCWithOutAddress
+        LCCIdWithoutAddress.parentSiteId = countrySiteId
+        const headers5 = await utils.getHeadersWithAuth()
+        let fetchResponse5 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers5,
+            method: 'POST',
+            body: JSON.stringify(LCCIdWithoutAddress),
+        })
+        let LCCWithoutAddressResponse = await fetchResponse5.json();
+        expect(fetchResponse5.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
+        expect(LCCWithoutAddressResponse.message).to.eql('argument No Address in payload failed validation')
+    });
+
+    it.only('User submits an API request to create a trial site with an address in LCC with no values populated, then an address is not associated with the trial site record and I receive an error notification', async () => {
+        let EmptyAddressId = requests.emptyAddressFields
+        EmptyAddressId.parentSiteId = countrySiteId
+        const headers6 = await utils.getHeadersWithAuth()
+        let fetchResponse6 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers6,
+            method: 'POST',
+            body: JSON.stringify(EmptyAddressId),
+        })
+        let EmptyAddressResponse = await fetchResponse6.json();
+        expect(fetchResponse6.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
+        expect(EmptyAddressResponse.message).to.eql('argument No Address in payload failed validation')
+    });
+});

--- a/api-tests/specs/practitioner-service/createperson.js
+++ b/api-tests/specs/practitioner-service/createperson.js
@@ -1,3 +1,9 @@
+/**
+ * Create person class covering roles regression test scenarios
+ * 
+ * Author Sameera Purini
+ * 
+ */
 const requests = require('../../data/practitioner-service/createperson')
 const conf = require('../../config/conf')
 const utils = require('../../common/utils')

--- a/api-tests/specs/profile/profile.js
+++ b/api-tests/specs/profile/profile.js
@@ -1,3 +1,10 @@
+/**
+ * Profile class covering roles regression test scenarios
+ * 
+ * Author Sameera Purini
+ * 
+ */
+
 const conf = require('../../config/conf')
 const utils = require('../../common/utils')
 const fetch = require("node-fetch");

--- a/api-tests/specs/role-service/permissions.js
+++ b/api-tests/specs/role-service/permissions.js
@@ -1,3 +1,9 @@
+/**
+ * Permission class covering roles regression test scenarios
+ * 
+ * Author Sameera Purini
+ * 
+ */
 const requests = require('../../data/role-service/permissions')
 const conf = require('../../config/conf')
 const endpointUri = '/api/roles';

--- a/api-tests/specs/role-service/roleservice.js
+++ b/api-tests/specs/role-service/roleservice.js
@@ -1,3 +1,9 @@
+/**
+ * Role Service class covering roles regression test scenarios
+ * 
+ * Author Sameera Purini
+ * 
+ */
 const requests = require('../../data/role-service/roleservice')
 const conf = require('../../config/conf')
 const endpointUri = '/api/roles';

--- a/api-tests/specs/zassign-roles/assign-roles.js
+++ b/api-tests/specs/zassign-roles/assign-roles.js
@@ -1,3 +1,9 @@
+/**
+ * Assign Role Service class covering roles regression test scenarios
+ * 
+ * Author Sameera Purini
+ * 
+ */
 const requests = require('../../data/assign-roles/assign-roles')
 const conf = require('../../config/conf')
 const sitesEndpointUri = '/api/sites';


### PR DESCRIPTION
The PR contains a set of scenarios to check the presence of an address at CCO and LCC level. Negative scenarios added to see if the address field present for non-configured sites like regions and countries fails.
Also updated the author name in the api test files that would help in tracking down the QA.

Changes

ARTS-207 -Address field added to the site with no validation

### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR
