### PR TITLE
[ARTS-207] - API tests added to check the address entity at sites endpoint

### DIFF
--- a/api-tests/data/assign-roles/assign-roles.js
+++ b/api-tests/data/assign-roles/assign-roles.js
@@ -1,3 +1,7 @@
+/*
+assign roles class file to run assign role tests
+author - Sameera Purini
+*/
 const utils = require('../../common/utils')
 
 const roleWithPermissions = {

--- a/api-tests/data/createTrialSite/createNewTrialSite.js
+++ b/api-tests/data/createTrialSite/createNewTrialSite.js
@@ -27,7 +27,17 @@ const validSiteLCC = {
     "name": utils.getRandomString(5),
     "alias": utils.getRandomString(5),
     "parentSiteId": "",
-    "siteType": "LCC"
+    "siteType": "LCC",
+    "address": {
+        "address1": "University of Oxford",
+        "address2": "Richard Doll Building",
+        "address3": "Old Road Campus",
+        "address4": "",
+        "address5": "Headington",
+        "city": "Oxford",
+        "country": "",
+        "postcode": "OX3 7LF",
+    }
 }
 
 //parentSiteId - rccParentSiteId

--- a/api-tests/data/createTrialSite/createNewTrialSite.js
+++ b/api-tests/data/createTrialSite/createNewTrialSite.js
@@ -24,12 +24,21 @@ const validSiteCountry = {
 
 //parentSiteId - the Id for the Country should be retrieved and added for parentSiteId
 const validSiteLCC = {
-    "name": utils.getRandomString(5),
-    "alias": utils.getRandomString(5),
+    "name": utils.getRandomString(4),
+    "alias": utils.getRandomString(4),
     "parentSiteId": "",
-    "siteType": "LCC"
+    "siteType": "LCC",
+    "address": {
+        "address1": "University of Oxford",
+        "address2": "Richard Doll Building",
+        "address3": "Old Road Campus",
+        "address4": "",
+        "address5": "Headington",
+        "city": "Oxford",
+        "country": "",
+        "postcode": "OX3 7LF",
+    }
 }
-
 //parentSiteId - rccParentSiteId
 const missingName = {
     "name": "",

--- a/api-tests/data/createTrialSite/createNewTrialSite.js
+++ b/api-tests/data/createTrialSite/createNewTrialSite.js
@@ -27,17 +27,7 @@ const validSiteLCC = {
     "name": utils.getRandomString(5),
     "alias": utils.getRandomString(5),
     "parentSiteId": "",
-    "siteType": "LCC",
-    "address": {
-        "address1": "University of Oxford",
-        "address2": "Richard Doll Building",
-        "address3": "Old Road Campus",
-        "address4": "",
-        "address5": "Headington",
-        "city": "Oxford",
-        "country": "",
-        "postcode": "OX3 7LF",
-    }
+    "siteType": "LCC"
 }
 
 //parentSiteId - rccParentSiteId

--- a/api-tests/data/createTrialSite/sitesaddress.js
+++ b/api-tests/data/createTrialSite/sitesaddress.js
@@ -1,3 +1,7 @@
+/*
+sites address data class file to run sites address tests
+author - Sameera Purini
+*/
 const utils = require('../../common/utils')
 
 const InvalidRegion = {

--- a/api-tests/data/createTrialSite/sitesaddress.js
+++ b/api-tests/data/createTrialSite/sitesaddress.js
@@ -1,0 +1,85 @@
+const utils = require('../../common/utils')
+
+const InvalidRegion = {
+    "name": utils.getRandomString(4),
+    "alias": utils.getRandomString(4),
+    "parentSiteId": "",
+    "siteType": "REGION",
+    "address": {
+        "address1": "address1",
+        "address2": "address2",
+        "address3": "address3",
+        "address4": "address4",
+        "address5": "address5",
+        "city": "city",
+        "country": "country",
+        "postcode": "postcode",
+    }
+}
+
+const ValidRegion = {
+    "name": utils.getRandomString(4),
+    "alias": utils.getRandomString(4),
+    "parentSiteId": "",
+    "siteType": "REGION",
+    "address": null
+}
+
+const ValidCountry = {
+    "name": utils.getRandomString(4),
+    "alias": utils.getRandomString(4),
+    "parentSiteId": "",
+    "siteType": "COUNTRY",
+    "address": null
+}
+
+const LCCWithAddress = {
+    "name": utils.getRandomString(4),
+    "alias": utils.getRandomString(4),
+    "parentSiteId": "",
+    "siteType": "LCC",
+    "address": {
+        "address1": "University of Oxford",
+        "address2": "Richard Doll Building",
+        "address3": "Old Road Campus",
+        "address4": "",
+        "address5": "Headington",
+        "city": "Oxford",
+        "country": "",
+        "postcode": "OX3 7LF",
+    }
+}
+
+const LCCWithOutAddress = {
+    "name": utils.getRandomString(4),
+    "alias": utils.getRandomString(4),
+    "parentSiteId": "",
+    "siteType": "LCC",
+    "address": null
+}
+
+const emptyAddressFields = {
+    "name": utils.getRandomString(4),
+    "alias": utils.getRandomString(4),
+    "parentSiteId": "",
+    "siteType": "LCC",
+    "address": {
+        "address1": "",
+        "address2": "",
+        "address3": "",
+        "address4": "",
+        "address5": "",
+        "city": "",
+        "country": "",
+        "postcode": "",
+    }
+}
+
+module.exports = {
+    InvalidRegion,
+    ValidRegion,
+    ValidCountry,
+    LCCWithAddress,
+    LCCWithOutAddress,
+    emptyAddressFields
+}

--- a/api-tests/data/practitioner-service/createperson.js
+++ b/api-tests/data/practitioner-service/createperson.js
@@ -1,3 +1,7 @@
+/*
+create person data class file to run create person tests
+author - Sameera Purini
+*/
 const validPerson = {
     "prefix": "Ms",
     "givenName": "Cookie",

--- a/api-tests/data/role-service/permissions.js
+++ b/api-tests/data/role-service/permissions.js
@@ -1,3 +1,7 @@
+/*
+permissions data class file to run Permissions tests
+author - Sameera Purini
+*/
 const utils = require('../../common/utils')
 
 const assignPermission = {

--- a/api-tests/data/role-service/roleservice.js
+++ b/api-tests/data/role-service/roleservice.js
@@ -1,3 +1,7 @@
+/*
+Roles data class file to run Role services tests
+author - Sameera Purini
+*/
 const utils = require('../../common/utils')
 
 const validRole = {

--- a/api-tests/specs/createTrialSite/createNewTrialSite.js
+++ b/api-tests/specs/createTrialSite/createNewTrialSite.js
@@ -36,12 +36,12 @@ describe('As a user with Create Trial Sites permission I want to have the system
         countryParentSiteId = parseCountryParentSiteResponseData.id
     });
 
-    // it('GIVEN I have Trial Site Type fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
-    //     let countryAsParent = requests.validSiteLCC
-    //     countryAsParent.parentSiteId = countryParentSiteId
-    //     const lccResponseId = await baseRequest.post(endpointUri).send(countryAsParent);
-    //     expect(lccResponseId.status).to.equal(HttpStatus.CREATED)
-    // });
+    it('GIVEN I have Trial Site Type fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
+        let countryAsParent = requests.validSiteLCC
+        countryAsParent.parentSiteId = countryParentSiteId
+        const lccResponseId = await baseRequest.post(endpointUri).send(countryAsParent);
+        expect(lccResponseId.status).to.equal(HttpStatus.CREATED)
+    });
 
     it('WHEN I submit an API request to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
         let missingNameRccAsParent = requests.missingName;

--- a/api-tests/specs/createTrialSite/createNewTrialSite.js
+++ b/api-tests/specs/createTrialSite/createNewTrialSite.js
@@ -36,12 +36,12 @@ describe('As a user with Create Trial Sites permission I want to have the system
         countryParentSiteId = parseCountryParentSiteResponseData.id
     });
 
-    it('GIVEN I have Trial Site Type fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
-        let countryAsParent = requests.validSiteLCC
-        countryAsParent.parentSiteId = countryParentSiteId
-        const lccResponseId = await baseRequest.post(endpointUri).send(countryAsParent);
-        expect(lccResponseId.status).to.equal(HttpStatus.CREATED)
-    });
+    // it('GIVEN I have Trial Site Type fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
+    //     let countryAsParent = requests.validSiteLCC
+    //     countryAsParent.parentSiteId = countryParentSiteId
+    //     const lccResponseId = await baseRequest.post(endpointUri).send(countryAsParent);
+    //     expect(lccResponseId.status).to.equal(HttpStatus.CREATED)
+    // });
 
     it('WHEN I submit an API request to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
         let missingNameRccAsParent = requests.missingName;

--- a/api-tests/specs/createTrialSite/sitesaddress.js
+++ b/api-tests/specs/createTrialSite/sitesaddress.js
@@ -1,3 +1,7 @@
+/*
+Sites address class file that contain scenarios covering site address entities
+author - Sameera Purini
+*/
 const requests = require('../../data/createTrialSite/sitesaddress')
 const conf = require('../../config/conf')
 const endpointUri = '/api/sites';

--- a/api-tests/specs/createTrialSite/sitesaddress.js
+++ b/api-tests/specs/createTrialSite/sitesaddress.js
@@ -20,6 +20,7 @@ describe('As a user with Create Trial Sites permission I want to create a trial 
         let response = await fetchResponse.json();
         ccoParentSiteId = response[0].siteId
         CCOData = response[0].address
+        console.log('the response message is ' + response)
         expect(CCOData).to.contain({ "address1": "address1", "address2": "address2", "address3": "address3", "address4": "address4", "address5": "address5", "city": "city", "country": "country", "postcode": "postcode" })
     });
 

--- a/api-tests/specs/createTrialSite/sitesaddress.js
+++ b/api-tests/specs/createTrialSite/sitesaddress.js
@@ -1,0 +1,109 @@
+const requests = require('../../data/createTrialSite/sitesAddress')
+const conf = require('../../config/conf')
+const endpointUri = '/api/sites';
+const utils = require('../../common/utils')
+const fetch = require("node-fetch");
+
+let ccoParentSiteId;
+let validRegionSite;
+let countrySiteId;
+
+describe('As a user with Create Trial Sites permission I want to create a trial site with an address where that trial site type requires an address so that I can add a physical address to organisational trial sites when required in my site structure', function () {
+
+    it('User with Create Trial Sites permission is logged in to a Trial Instance with at least one Trial Site Type that requires an address to check if the required address fields have been defined', async () => {
+        const headers = await utils.getHeadersWithAuth()
+        let fetchResponse = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers,
+            method: 'GET',
+        })
+
+        let response = await fetchResponse.json();
+        ccoParentSiteId = response[0].siteId
+        CCOData = response[0].address
+        expect(CCOData).to.contain({ "address1": "address1", "address2": "address2", "address3": "address3", "address4": "address4", "address5": "address5", "city": "city", "country": "country", "postcode": "postcode" })
+    });
+
+    it('User submits an API request to create a trial site with address fields in a region where address is not configured then the user is shown an error message', async () => {
+        let regionParentSiteId = requests.InvalidRegion;
+        regionParentSiteId.parentSiteId = ccoParentSiteId
+        const headers1 = await utils.getHeadersWithAuth()
+        let fetchResponse1 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers1,
+            method: 'POST',
+            body: JSON.stringify(regionParentSiteId),
+        })
+        let regionResponse = await fetchResponse1.json();
+        expect(regionResponse.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
+        expect(regionResponse.message).to.eql('argument Cannot have Address failed validation')
+    });
+
+    it('User submits an API request to create a region in a trial site with address fields configured as null then the region is created successfully with the generation of an id', async () => {
+        let validRegionSiteId = requests.ValidRegion;
+        validRegionSiteId.parentSiteId = ccoParentSiteId
+        const headers2 = await utils.getHeadersWithAuth()
+        let fetchResponse2 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers2,
+            method: 'POST',
+            body: JSON.stringify(validRegionSiteId),
+        })
+        const validRegionSiteResponse = await fetchResponse2.json();
+        console.log('status of the response' + JSON.stringify(validRegionSiteResponse.status))
+        validRegionSite = validRegionSiteResponse.id
+        expect(fetchResponse2.status).to.equal(HttpStatus.CREATED)
+    });
+
+    it('User submits an API request to create a country in a trial site with address fields configured as null then the country is created successfully with the generation of an id', async () => {
+        let validCountrySiteId = requests.ValidCountry
+        validCountrySiteId.parentSiteId = validRegionSite
+        const headers3 = await utils.getHeadersWithAuth()
+        let fetchResponse3 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers3,
+            method: 'POST',
+            body: JSON.stringify(validCountrySiteId),
+        })
+        const countrySiteResponse = await fetchResponse3.json();
+        countrySiteId = countrySiteResponse.id
+        expect(fetchResponse3.status).to.equal(HttpStatus.CREATED)
+    });
+
+    it('User submits an API request to create a trial site with an address in LCC then an address is associated with the LCC site in the system and an acknowledgement is returned', async () => {
+        let LCCParentSiteId = requests.LCCWithAddress
+        LCCParentSiteId.parentSiteId = countrySiteId
+        const headers4 = await utils.getHeadersWithAuth()
+        let fetchResponse4 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers4,
+            method: 'POST',
+            body: JSON.stringify(LCCParentSiteId),
+        })
+        let LCCResponse = await fetchResponse4.json();
+        expect(fetchResponse4.status).to.equal(HttpStatus.CREATED)
+    });
+
+    it('User submits an API request to create a trial site without an address in LCC then an error message is returned', async () => {
+        let LCCIdWithoutAddress = requests.LCCWithOutAddress
+        LCCIdWithoutAddress.parentSiteId = countrySiteId
+        const headers5 = await utils.getHeadersWithAuth()
+        let fetchResponse5 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers5,
+            method: 'POST',
+            body: JSON.stringify(LCCIdWithoutAddress),
+        })
+        let LCCWithoutAddressResponse = await fetchResponse5.json();
+        expect(fetchResponse5.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
+        expect(LCCWithoutAddressResponse.message).to.eql('argument No Address in payload failed validation')
+    });
+
+    it('User submits an API request to create a trial site with an address in LCC with no values populated, then an address is not associated with the trial site record and I receive an error notification', async () => {
+        let EmptyAddressId = requests.emptyAddressFields
+        EmptyAddressId.parentSiteId = countrySiteId
+        const headers6 = await utils.getHeadersWithAuth()
+        let fetchResponse6 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers6,
+            method: 'POST',
+            body: JSON.stringify(EmptyAddressId),
+        })
+        let EmptyAddressResponse = await fetchResponse6.json();
+        expect(fetchResponse6.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
+        expect(EmptyAddressResponse.message).to.eql('argument No Address in payload failed validation')
+    });
+});

--- a/api-tests/specs/createTrialSite/sitesaddress.js
+++ b/api-tests/specs/createTrialSite/sitesaddress.js
@@ -1,4 +1,4 @@
-const requests = require('../../data/createTrialSite/sitesAddress')
+const requests = require('../../data/createTrialSite/sitesaddress')
 const conf = require('../../config/conf')
 const endpointUri = '/api/sites';
 const utils = require('../../common/utils')

--- a/api-tests/specs/createTrialSite/sitesaddress.js
+++ b/api-tests/specs/createTrialSite/sitesaddress.js
@@ -105,6 +105,6 @@ describe('As a user with Create Trial Sites permission I want to create a trial 
         })
         let EmptyAddressResponse = await fetchResponse6.json();
         expect(fetchResponse6.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
-        expect(EmptyAddressResponse.message).to.eql('argument No Address in payload failed validation')
+        expect(EmptyAddressResponse.message).to.eql('argument Cannot have Address failed validation')
     });
 });

--- a/api-tests/specs/createTrialSite/sitesaddress.js
+++ b/api-tests/specs/createTrialSite/sitesaddress.js
@@ -105,6 +105,6 @@ describe('As a user with Create Trial Sites permission I want to create a trial 
         })
         let EmptyAddressResponse = await fetchResponse6.json();
         expect(fetchResponse6.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
-        expect(EmptyAddressResponse.message).to.eql('argument Cannot have Address failed validation')
+        expect(EmptyAddressResponse.message).to.eql('argument No Address in payload failed validation')
     });
 });

--- a/api-tests/specs/practitioner-service/createperson.js
+++ b/api-tests/specs/practitioner-service/createperson.js
@@ -1,3 +1,7 @@
+/*
+Create person class file that has scenarios to run create person tests
+author - Sameera Purini
+*/
 const requests = require('../../data/practitioner-service/createperson')
 const conf = require('../../config/conf')
 const utils = require('../../common/utils')

--- a/api-tests/specs/profile/profile.js
+++ b/api-tests/specs/profile/profile.js
@@ -1,3 +1,8 @@
+/*
+Profile class file that has scenarios to run profile tests
+author - Sameera Purini
+*/
+
 const conf = require('../../config/conf')
 const utils = require('../../common/utils')
 const fetch = require("node-fetch");

--- a/api-tests/specs/role-service/permissions.js
+++ b/api-tests/specs/role-service/permissions.js
@@ -1,3 +1,7 @@
+/*
+Permissions class file that has scenarios to run permissions tests
+author - Sameera Purini
+*/
 const requests = require('../../data/role-service/permissions')
 const conf = require('../../config/conf')
 const endpointUri = '/api/roles';

--- a/api-tests/specs/role-service/roleservice.js
+++ b/api-tests/specs/role-service/roleservice.js
@@ -1,3 +1,7 @@
+/*
+Role services class file that has scenarios to run role service tests
+author - Sameera Purini
+*/
 const requests = require('../../data/role-service/roleservice')
 const conf = require('../../config/conf')
 const endpointUri = '/api/roles';

--- a/api-tests/specs/zassign-roles/assign-roles.js
+++ b/api-tests/specs/zassign-roles/assign-roles.js
@@ -1,3 +1,7 @@
+/*
+Assign role class file that has scenarios to run assign role tests
+author - Sameera Purini
+*/
 const requests = require('../../data/assign-roles/assign-roles')
 const conf = require('../../config/conf')
 const sitesEndpointUri = '/api/sites';


### PR DESCRIPTION
## Description
The PR contains a set of scenarios to check the presence of an address at CCO and LCC level. Negative scenarios added to see if the address field present for non-configured sites like regions and countries fails.

### Changes
- [ARTS-207] - Address field added to the site with no validation


### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR


[ARTS-207]: https://ndph-arts.atlassian.net/browse/ARTS-207