### PR TITLE
[ARTS-827] Use actuator for health checks

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -181,6 +181,7 @@ jobs:
         if: always()
         run: |
           docker-compose logs --tail="all" > docker-compose.log
+          docker-compose ps
       - name: Upload docker-compose logs
         if: always()
         uses: actions/upload-artifact@v2

--- a/config-server/src/main/resources/application.yml
+++ b/config-server/src/main/resources/application.yml
@@ -1,2 +1,16 @@
 server:
   port: 8888
+spring:
+  cloud:
+    config:
+      server:
+        git:
+          default-label: main
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  health:
+    probes:
+      enabled: true

--- a/discovery-server/src/main/resources/application.yml
+++ b/discovery-server/src/main/resources/application.yml
@@ -9,3 +9,11 @@ eureka:
     fetchRegistry: false
     serviceUrl:
       defaultZone: http://${eureka.instance.hostname}:${server.port}/eureka/
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  health:
+    probes:
+      enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       AZURE_ACTIVEDIRECTORY_CLIENT-ID: ${MTS_AZURE_APP_CLIENT_ID}
       INIT-SERVICE_IDENTITY: ${INIT_SERVICE_ACCOUNT_OBJECTID}
     healthcheck:
-      test: curl http://localhost:8081/actuator/health/readiness
+      test: curl --fail http://localhost:8081/actuator/health
       interval: 10s
       timeout: 10s
       retries: 12
@@ -53,7 +53,7 @@ services:
     depends_on:
       - sql
     healthcheck:
-      test: curl http://localhost:8082/actuator/health/readiness
+      test: curl --fail http://localhost:8082/actuator/health
       interval: 10s
       timeout: 10s
       retries: 12
@@ -77,7 +77,7 @@ services:
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
       INIT-SERVICE_IDENTITY: ${INIT_SERVICE_ACCOUNT_OBJECTID}
     healthcheck:
-      test: curl http://localhost:8083/actuator/health/readiness
+      test: curl --fail http://localhost:8083/actuator/health
       interval: 10s
       timeout: 10s
       retries: 6 # a quick service
@@ -154,7 +154,7 @@ services:
     ports:
       - "8888:8888"
     healthcheck:
-      test: curl http://localhost:8888/actuator/health/readiness
+      test: curl --fail http://localhost:8888/actuator/health/liveness
       interval: 10s
       timeout: 10s
       retries: 6 # a quick service
@@ -177,7 +177,7 @@ services:
     ports:
       - "8761:8761"
     healthcheck:
-      test: curl http://localhost:8761/actuator/health/readiness
+      test: curl --fail http://localhost:8761/actuator/health/liveness
       interval: 10s
       timeout: 10s
       retries: 6 # a quick service
@@ -195,7 +195,7 @@ services:
     ports:
       - "8080:8080"
     healthcheck:
-      test: curl http://localhost:8080/
+      test: curl --fail http://localhost:8080/actuator/health
       interval: 10s
       timeout: 10s
       retries: 6 # a quick service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       AZURE_ACTIVEDIRECTORY_CLIENT-ID: ${MTS_AZURE_APP_CLIENT_ID}
       INIT-SERVICE_IDENTITY: ${INIT_SERVICE_ACCOUNT_OBJECTID}
     healthcheck:
-      test: curl http://localhost:8081
+      test: curl http://localhost:8081/actuator/health/readiness
       interval: 10s
       timeout: 10s
       retries: 12
@@ -53,7 +53,7 @@ services:
     depends_on:
       - sql
     healthcheck:
-      test: curl http://localhost:8082
+      test: curl http://localhost:8082/actuator/health/readiness
       interval: 10s
       timeout: 10s
       retries: 12
@@ -77,7 +77,7 @@ services:
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
       INIT-SERVICE_IDENTITY: ${INIT_SERVICE_ACCOUNT_OBJECTID}
     healthcheck:
-      test: curl http://localhost:8083
+      test: curl http://localhost:8083/actuator/health/readiness
       interval: 10s
       timeout: 10s
       retries: 6 # a quick service
@@ -154,7 +154,7 @@ services:
     ports:
       - "8888:8888"
     healthcheck:
-      test: curl http://localhost:8888/
+      test: curl http://localhost:8888/actuator/health/readiness
       interval: 10s
       timeout: 10s
       retries: 6 # a quick service
@@ -177,7 +177,7 @@ services:
     ports:
       - "8761:8761"
     healthcheck:
-      test: curl http://localhost:8761/
+      test: curl http://localhost:8761/actuator/health/readiness
       interval: 10s
       timeout: 10s
       retries: 6 # a quick service

--- a/pom.springcloud.xml
+++ b/pom.springcloud.xml
@@ -21,6 +21,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
     </dependencies>
 

--- a/sample-service/src/main/resources/application-local.properties
+++ b/sample-service/src/main/resources/application-local.properties
@@ -1,5 +1,0 @@
-azure.keyvault.enabled=false
-azure.keyvault.uri=https://ityekv.vault.azure.net/
-application.message="My app settings value here"
-spring.main.allow-bean-definition-overriding=true
-init-service.identity=<init-service-identity>

--- a/sample-service/src/main/resources/application-local.yml
+++ b/sample-service/src/main/resources/application-local.yml
@@ -4,3 +4,10 @@ azure:
   keyvault:
     enabled: false
     uri: https://ityekv.vault.azure.net/
+
+spring:
+    main:
+      allow-bean-definition-overriding: true
+
+init-service:
+  identity: <init-service-identity>


### PR DESCRIPTION
## Description
Update spring cloud services to also use actuator and docker-compose to use its readiness probe for health checks.
This PR should fail until https://github.com/NDPH-ARTS/mts-trial-deployment-config/pull/93 is merged

### Changes
- [ARTS-827] - use actuator for health checks

### Checklist:

- [x] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-827]: https://ndph-arts.atlassian.net/browse/ARTS-827