### PR TITLE
Init service starts only when ALL expected services are registered

### DIFF
--- a/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/loader/Loader.java
+++ b/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/loader/Loader.java
@@ -51,8 +51,8 @@ public class Loader implements CommandLineRunner {
         initProgressReporter.submitProgress(String.format(LoaderProgress.ENTRY_POINT.message(), delayStartInSeconds));
         Thread.sleep(delayStartInSeconds * 1000);
 
-        var allReady = false;
-        while (!allReady) {
+        boolean allReady;
+        do {
             initProgressReporter.submitProgress(LoaderProgress.WAITING_FOR_ALL.message());
 
             var applications = this.discoveryClient.getServices();
@@ -65,12 +65,10 @@ public class Loader implements CommandLineRunner {
 
             allReady = applications.containsAll(
                 Arrays.asList("config-server", "site-service", "role-service", "practitioner-service"));
-            if (allReady) {
-                break;
+            if (!allReady) {
+                Thread.sleep(5000);
             }
-
-            Thread.sleep(5000);
-        }
+        } while (!allReady);
 
         initProgressReporter.submitProgress(LoaderProgress.ALL_REGISTERED.message());
 

--- a/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/loader/Loader.java
+++ b/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/loader/Loader.java
@@ -3,18 +3,21 @@ package uk.ac.ox.ndph.mts.init_service.loader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.stereotype.Component;
 import uk.ac.ox.ndph.mts.init_service.model.Trial;
 import uk.ac.ox.ndph.mts.init_service.service.InitProgressReporter;
 import uk.ac.ox.ndph.mts.init_service.service.PractitionerServiceInvoker;
 import uk.ac.ox.ndph.mts.init_service.service.SiteServiceInvoker;
 import uk.ac.ox.ndph.mts.roleserviceclient.RoleServiceClient;
-
+import org.springframework.cloud.client.discovery.DiscoveryClient;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 @Component
+@EnableDiscoveryClient
 public class Loader implements CommandLineRunner {
 
     private final PractitionerServiceInvoker practitionerServiceInvoker;
@@ -22,6 +25,9 @@ public class Loader implements CommandLineRunner {
     private final SiteServiceInvoker siteServiceInvoker;
     private final Trial trialConfig;
     private final InitProgressReporter initProgressReporter;
+
+    @Autowired
+    private DiscoveryClient discoveryClient;
 
     @Value("${delay-start:1}")
     private long delayStartInSeconds;
@@ -43,8 +49,30 @@ public class Loader implements CommandLineRunner {
     @Override
     public void run(String... args) throws InterruptedException, IOException {
         // Give the other services some time to come online.
+        // We wait and query the discovery to see that our services are up and ready
         initProgressReporter.submitProgress(String.format(LoaderProgress.ENTRY_POINT.message(), delayStartInSeconds));
         Thread.sleep(delayStartInSeconds * 1000);
+
+        var allReady = false;
+        while (!allReady) {
+            initProgressReporter.submitProgress("Waiting for all services to be registered");
+
+            var applications = this.discoveryClient.getServices();
+            initProgressReporter.submitProgress(applications.size() + " services are registered");
+            for (var application : applications) {
+                initProgressReporter.submitProgress(application + " is registered");
+            }
+
+            allReady = applications.containsAll(
+                Arrays.asList("config-server", "site-service", "role-service", "practitioner-service"));
+            if (allReady) {
+                break;
+            }
+
+            Thread.sleep(10000);
+        }
+
+        initProgressReporter.submitProgress("All services were registered. Continue.");
 
         try {
             initProgressReporter.submitProgress(LoaderProgress.GET_ROLES_FROM_CONFIG.message());
@@ -63,14 +91,13 @@ public class Loader implements CommandLineRunner {
             var persons = trialConfig.getPersons();
 
             initProgressReporter.submitProgress(String.format(
-                    LoaderProgress.SELECT_FIRST_SITE_FROM_COLLECTION_OF_SIZE.message(), siteIds.size()));
+                LoaderProgress.SELECT_FIRST_SITE_FROM_COLLECTION_OF_SIZE.message(), siteIds.size()));
             // Assumption in story https://ndph-arts.atlassian.net/browse/ARTS-164
             String siteIdForUserRoles = siteIds.get(0);
             initProgressReporter.submitProgress(LoaderProgress.CREATE_PRACTITIONER.message());
             practitionerServiceInvoker.execute(persons, siteIdForUserRoles);
             initProgressReporter.submitProgress(LoaderProgress.FINISHED_SUCCESSFULY.message());
-        }
-        catch (Exception ex) {
+        } catch (Exception ex) {
             initProgressReporter.submitProgress(ex.toString());
             initProgressReporter.submitProgress(LoaderProgress.FAILURE.message());
             throw ex;

--- a/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/loader/LoaderProgress.java
+++ b/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/loader/LoaderProgress.java
@@ -9,6 +9,10 @@ public enum LoaderProgress {
     GET_PERSONS_FROM_CONFIG("getting persons from config."),
     SELECT_FIRST_SITE_FROM_COLLECTION_OF_SIZE("selecting the first side id out of %d"),
     CREATE_PRACTITIONER("creating practitioner."),
+    WAITING_FOR_ALL("waiting for all services to be registered"),
+    N_SERVICES_REGISTERED("%d services are registered"),
+    SERVICE_REGISTERED("service '%s' is registered"),
+    ALL_REGISTERED("all services were registered. Continue"),
     //These are token messages, if you change this you need to change in github action as well!
     FINISHED_SUCCESSFULY("***SUCCESS***"),
     FAILURE("***FAILURE***");

--- a/init-service/src/test/java/uk/ac/ox/ndph/mts/init_service/loader/LoaderTest.java
+++ b/init-service/src/test/java/uk/ac/ox/ndph/mts/init_service/loader/LoaderTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
 import uk.ac.ox.ndph.mts.init_service.exception.NullEntityException;
 import uk.ac.ox.ndph.mts.init_service.model.Practitioner;
 import uk.ac.ox.ndph.mts.init_service.model.Site;
@@ -17,6 +18,7 @@ import uk.ac.ox.ndph.mts.roleserviceclient.model.PermissionDTO;
 import uk.ac.ox.ndph.mts.roleserviceclient.model.RoleDTO;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Consumer;
 
@@ -37,18 +39,24 @@ class LoaderTest {
     PractitionerServiceInvoker practitionerServiceInvoker;
 
     @Mock
+    DiscoveryClient discoveryClient;
+
+    @Mock
     InitProgressReporter initProgressReporter;
 
     @Test
     void testLoader() throws InterruptedException, IOException {
         Loader loader = new Loader(mockedTrial(),
-                            practitionerServiceInvoker,
-                            roleServiceClient,
-                            siteServiceInvoker,
-                            initProgressReporter);
+            practitionerServiceInvoker,
+            roleServiceClient,
+            siteServiceInvoker,
+            initProgressReporter,
+            discoveryClient);
 
         doReturn(Collections.singletonList("dummy-role-id")).when(roleServiceClient).createMany(anyList(), any(Consumer.class));
         doReturn(Collections.singletonList("dummy-site-id")).when(siteServiceInvoker).execute(anyList());
+        doReturn(Arrays.asList("config-server", "site-service", "role-service", "practitioner-service"))
+            .when(discoveryClient).getServices();
         doNothing().when(practitionerServiceInvoker).execute(anyList(), anyString());
 
         loader.run();
@@ -61,10 +69,57 @@ class LoaderTest {
     @Test
     void testLoader_ThrowException() throws IOException, InterruptedException {
         //doThrow(InterruptedException.class).when(roleServiceInvoker).execute(anyList());
+        doReturn(Arrays.asList("config-server", "site-service", "role-service", "practitioner-service"))
+            .when(discoveryClient).getServices();
+
         when(roleServiceClient.createMany(anyList(), any(Consumer.class))).thenThrow(new NullEntityException(anyString()));
 
-        Loader loader = new Loader(mockedTrial(), practitionerServiceInvoker, roleServiceClient, siteServiceInvoker, initProgressReporter);
+        Loader loader = new Loader(mockedTrial(), practitionerServiceInvoker, roleServiceClient, siteServiceInvoker, initProgressReporter, discoveryClient);
         Assertions.assertThrows(NullEntityException.class, loader::run);
+    }
+
+    /**
+     * Register only 1 service (instead of all 4), and expect the loader to be blocked.
+     * We verify it is blocked by checking how many times 'getServices' were called in
+     * a given time window
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    @Test
+    void testLoader_ServicesNotRegistered_LoaderBlocked() throws IOException, InterruptedException {
+        doReturn(Arrays.asList("config-server"))
+            .when(discoveryClient).getServices();
+
+        Loader loader =
+            new Loader(mockedTrial(), practitionerServiceInvoker, roleServiceClient, siteServiceInvoker, initProgressReporter, discoveryClient);
+
+        // start a thread for the runner
+        new Thread(() -> {
+            try {
+                loader.run();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }).start();
+
+        // verify that the loader called 'getServices' at least 5 times in that time frame, means it stuck
+        verify(discoveryClient, timeout(30000).atLeast(5)).getServices();
+    }
+
+    @Test
+    void testLoader_LoaderWaitForServices_ThenContinue() throws IOException, InterruptedException {
+        doReturn(Arrays.asList("config-server", "site-service", "role-service", "practitioner-service"))
+            .when(discoveryClient).getServices();
+
+        when(roleServiceClient.createMany(anyList(), any(Consumer.class))).thenThrow(new NullEntityException(anyString()));
+
+        Loader loader = new Loader(mockedTrial(), practitionerServiceInvoker, roleServiceClient, siteServiceInvoker, initProgressReporter, discoveryClient);
+        Assertions.assertThrows(NullEntityException.class, loader::run);
+
+        // Verify the loader wasn't blocked and the number of invocations of getServices is exactly 1
+        verify(discoveryClient, timeout(1000).times(1)).getServices();
     }
 
     Trial mockedTrial() {


### PR DESCRIPTION
## Description
Init service starts only when ALL expected services are registered.
In this way we improve the init service to succeed and not reach any undesired state due to partial initialization.

It can still happen (e.g. service is unregistered after the check was done), but it improves the chance of success.

### Changes
Discovery client was added to the init-service. We query it for the registered services and we block the init until we verify all are registered.

![image](https://user-images.githubusercontent.com/13205761/113571414-06f7fc80-961f-11eb-82b4-b9f23f1db7d1.png)


### Checklist:

- [x] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
