### PR TITLE
[FIX] Add missing permissions to allow ci to be green

### DIFF
--- a/role-service/src/main/resources/db/changelog/changelog-permission-data.xml
+++ b/role-service/src/main/resources/db/changelog/changelog-permission-data.xml
@@ -23,5 +23,17 @@
             <column name="modified_by" value="darrsmi"/>
         </insert>
 
+        <insert tableName="permission">
+            <column name="id" value="link-user"/>
+            <column name="created_by" value="darrsmi"/>
+            <column name="modified_by" value="darrsmi"/>
+        </insert>
+
+        <insert tableName="permission">
+            <column name="id" value="create-site"/>
+            <column name="created_by" value="katesan"/>
+            <column name="modified_by" value="katesan"/>
+        </insert>
+
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Description
Missing permissions in the db are added for the CI to be green again.

### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
