### PR TITLE
[ARTS-827] Improve stability and health checks on docker-compose

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -67,6 +67,7 @@ jobs:
             exit 0
           fi
 
+          echo "Trying to pull the deps image (if exists) ..."
           set +o errexit
           docker pull $DEPS_TAG
           DEPS_VALUE=$?
@@ -148,8 +149,8 @@ jobs:
           AZURE_CLIENT_ID: a2171b8b-4e97-4523-933a-dc18ef7ef1fe
           AZURE_TENANT_ID: 5d23383f-2acb-448e-8353-4b4573b82276
           AZURE_CLIENT_SECRET: ${{ secrets.CI_CLIENT_SECRET }}
-        run: |
-          ./.ci/docker/check-docker-compose-services.sh
+          LOGGING_LEVEL_ROOT: DEBUG
+        run: ./.ci/docker/check-docker-compose-services.sh
       - name: Run init
         env:
           PROFILE: dev
@@ -180,13 +181,20 @@ jobs:
       - name: Prepare docker-compose logs
         if: always()
         run: |
-          docker-compose logs --tail="all" > docker-compose.log
+          docker-compose ps
+
+          mkdir run-logs
+          docker-compose logs --no-color --timestamps --tail="all" > ./run-logs/all.log
+          for service_name in discovery-server config-server gateway-server role-service site-service practitioner-service; do
+            docker-compose logs --no-color --timestamps --tail="all" ${service_name} > ./run-logs/${service_name}.log
+          done
+
       - name: Upload docker-compose logs
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: docker-compose-logs
-          path: docker-compose.log
+          name: logs
+          path: run-logs/
       - name: Process API Tests Report
         if: always()
         uses: scacap/action-surefire-report@v1

--- a/config-server/src/main/resources/application.yml
+++ b/config-server/src/main/resources/application.yml
@@ -1,2 +1,16 @@
 server:
   port: 8888
+spring:
+  cloud:
+    config:
+      server:
+        git:
+          default-label: main
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  health:
+    probes:
+      enabled: true

--- a/discovery-server/src/main/resources/application.yml
+++ b/discovery-server/src/main/resources/application.yml
@@ -9,3 +9,11 @@ eureka:
     fetchRegistry: false
     serviceUrl:
       defaultZone: http://${eureka.instance.hostname}:${server.port}/eureka/
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  health:
+    probes:
+      enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,9 @@ services:
       # This is the id of the client application
       AZURE_ACTIVEDIRECTORY_CLIENT-ID: ${MTS_AZURE_APP_CLIENT_ID}
       INIT-SERVICE_IDENTITY: ${INIT_SERVICE_ACCOUNT_OBJECTID}
+      LOGGING_LEVEL_ROOT: ${LOGGING_LEVEL_ROOT:-INFO}
     healthcheck:
-      test: curl http://localhost:8081
+      test: curl --fail http://localhost:8081/actuator/health
       interval: 10s
       timeout: 10s
       retries: 12
@@ -41,6 +42,7 @@ services:
       args:
         SVC: role-service
     image: ghcr.io/ndph-arts/role-service:${GITHUB_SHA}
+    restart: on-failure
     environment:
       SERVER_PORT: "8082"
       JDBC_DRIVER: com.microsoft.sqlserver.jdbc.SQLServerDriver
@@ -50,10 +52,11 @@ services:
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
       INIT-SERVICE_IDENTITY: ${INIT_SERVICE_ACCOUNT_OBJECTID}
+      LOGGING_LEVEL_ROOT: ${LOGGING_LEVEL_ROOT:-INFO}
     depends_on:
       - sql
     healthcheck:
-      test: curl http://localhost:8082
+      test: curl --fail http://localhost:8082/actuator/health
       interval: 10s
       timeout: 10s
       retries: 12
@@ -66,6 +69,7 @@ services:
       args:
         SVC: site-service
     image: ghcr.io/ndph-arts/site-service:${GITHUB_SHA}
+    restart: on-failure
     depends_on:
       - fhir-api
     environment:
@@ -76,8 +80,9 @@ services:
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
       INIT-SERVICE_IDENTITY: ${INIT_SERVICE_ACCOUNT_OBJECTID}
+      LOGGING_LEVEL_ROOT: ${LOGGING_LEVEL_ROOT:-INFO}
     healthcheck:
-      test: curl http://localhost:8083
+      test: curl --fail http://localhost:8083/actuator/health
       interval: 10s
       timeout: 10s
       retries: 6 # a quick service
@@ -95,7 +100,7 @@ services:
       args:
         SVC: init-service
     image: ghcr.io/ndph-arts/init-service:${GITHUB_SHA}
-    restart: on-failure
+    restart: "no"
     environment:
       PRACTITIONER_SERVICE_URI: "http://practitioner-service:8081"
       ROLE_SERVICE_URI: "http://role-service:8082"
@@ -108,10 +113,7 @@ services:
       AZURE_USERNAME: ${INIT_SERVICE_ACCOUNT_USERNAME}
       AZURE_PASSWORD: ${INIT_SERVICE_ACCOUNT_PASSWORD}
       AZURE_CLIENT_ID: ${MTS_AZURE_APP_CLIENT_ID}
-      LOGGING_LEVEL_UK_AC_OX_NDPH_MTS: DEBUG
-    deploy:
-      restart_policy:
-          condition: none
+      LOGGING_LEVEL_ROOT: DEBUG # always debug
     depends_on:
       - practitioner-service
       - role-service
@@ -132,6 +134,11 @@ services:
       - "8099:8099"
     depends_on:
       - sql
+    healthcheck:
+      test: busybox wget -O- http://localhost:8099
+      interval: 10s
+      timeout: 10s
+      retries: 12
 
   #########################
   # SPRING CLOUD SERVICES #
@@ -154,7 +161,7 @@ services:
     ports:
       - "8888:8888"
     healthcheck:
-      test: curl http://localhost:8888/
+      test: curl --fail http://localhost:8888/actuator/health/liveness
       interval: 10s
       timeout: 10s
       retries: 6 # a quick service
@@ -177,7 +184,7 @@ services:
     ports:
       - "8761:8761"
     healthcheck:
-      test: curl http://localhost:8761/
+      test: curl --fail http://localhost:8761/actuator/health/liveness
       interval: 10s
       timeout: 10s
       retries: 6 # a quick service
@@ -195,7 +202,7 @@ services:
     ports:
       - "8080:8080"
     healthcheck:
-      test: curl http://localhost:8080/
+      test: curl --fail http://localhost:8080/actuator/health
       interval: 10s
       timeout: 10s
       retries: 6 # a quick service
@@ -206,6 +213,7 @@ services:
 
   sql:
     image: "mcr.microsoft.com/mssql/server"
+    restart: on-failure
     environment:
       SA_PASSWORD: ${SAPASSWORD}
       ACCEPT_EULA: "Y"

--- a/init-service/pom.xml
+++ b/init-service/pom.xml
@@ -71,6 +71,11 @@
             <version>0.0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/init-service/src/main/resources/bootstrap.yml
+++ b/init-service/src/main/resources/bootstrap.yml
@@ -7,6 +7,10 @@ spring:
         enabled: true
         service-id: CONFIG-SERVER
       fail-fast: true
+      retry:
+        max-attempts: 10
+        max-interval: 5000
+        multiplier: 1.5
 
 eureka:
   client:

--- a/pom.springcloud.xml
+++ b/pom.springcloud.xml
@@ -21,6 +21,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
     </dependencies>
 

--- a/sample-service/src/main/resources/application-local.properties
+++ b/sample-service/src/main/resources/application-local.properties
@@ -1,5 +1,0 @@
-azure.keyvault.enabled=false
-azure.keyvault.uri=https://ityekv.vault.azure.net/
-application.message="My app settings value here"
-spring.main.allow-bean-definition-overriding=true
-init-service.identity=<init-service-identity>

--- a/sample-service/src/main/resources/application-local.yml
+++ b/sample-service/src/main/resources/application-local.yml
@@ -4,3 +4,10 @@ azure:
   keyvault:
     enabled: false
     uri: https://ityekv.vault.azure.net/
+
+spring:
+    main:
+      allow-bean-definition-overriding: true
+
+init-service:
+  identity: <init-service-identity>


### PR DESCRIPTION
## Description
Improve the overall stability of the docker-compose based system.

### Changes
- [ARTS-827] - Update spring cloud services to also use actuator and docker-compose to use its liveness probe for health checks.
- Align restart policy on docker-compose
- Add retry for config on the init-service (probably should be replicated to the others as well)

### Checklist:

- [x] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-827]: https://ndph-arts.atlassian.net/browse/ARTS-827