### PR TITLE
[ARTS-622] - API tests covering create site auth feature

### DIFF
--- a/api-tests/data/createTrialSite/createNewTrialSite.js
+++ b/api-tests/data/createTrialSite/createNewTrialSite.js
@@ -1,10 +1,7 @@
+/* data class file with/out create-site permission
+author: Samee Syed
+ */
 const utils = require('../../common/utils')
-//creating a parent as CCO with no existing node
-const validSiteCCO = {
-    "name": "CCOUK",
-    "alias": "CCO",
-    "parentSiteId": ""
-}
 
 //parentSiteId - the Id for the CCO should be retrieved and added for parentSiteId
 const validSiteRCC = {
@@ -32,13 +29,14 @@ const validSiteLCC = {
         "address1": "University of Oxford",
         "address2": "Richard Doll Building",
         "address3": "Old Road Campus",
-        "address4": "",
+        "address4": "RDrive",
         "address5": "Headington",
         "city": "Oxford",
-        "country": "",
+        "country": "UK",
         "postcode": "OX3 7LF",
     }
 }
+
 //parentSiteId - rccParentSiteId
 const missingName = {
     "name": "",
@@ -94,7 +92,7 @@ const missingParent = {
     "siteType": "REGION"
 }
 
-const invalidParentType = {
+const invalidSiteType = {
     "name": utils.getRandomString(5),
     "alias": utils.getRandomString(5),
     "parentSiteId": "",
@@ -109,24 +107,7 @@ const duplicateName = {
     "siteType": "REGION"
 }
 
-//parentSiteId - rccParentSiteId
-const duplicateAlias = {
-    "name": utils.getRandomString(5),
-    "alias": "rcc",
-    "parentSiteId": "",
-    "siteType": "REGION"
-}
-
-//parentSiteId - rccParentSiteId
-const duplicateBoth = {
-    "name": "uk",
-    "alias": "uk",
-    "parentSiteId": "",
-    "siteType": "REGION"
-}
-
 module.exports = {
-    validSiteCCO,
     validSiteRCC,
     validSiteCountry,
     validSiteLCC,
@@ -137,8 +118,6 @@ module.exports = {
     exceedingAlias,
     exceedingBoth,
     missingParent,
-    invalidParentType,
-    duplicateName,
-    duplicateAlias,
-    duplicateBoth
+    invalidSiteType,
+    duplicateName
 }

--- a/api-tests/data/createTrialSite/createNewTrialSite.js
+++ b/api-tests/data/createTrialSite/createNewTrialSite.js
@@ -101,8 +101,8 @@ const invalidSiteType = {
 
 //parentSiteId - rccParentSiteId
 const duplicateName = {
-    "name": "rccuk",
-    "alias": utils.getRandomString(5),
+    "name": "duplicateName",
+    "alias": "duplicateName",
     "parentSiteId": "",
     "siteType": "REGION"
 }

--- a/api-tests/data/createTrialSite/createSitePermission.js
+++ b/api-tests/data/createTrialSite/createSitePermission.js
@@ -1,0 +1,16 @@
+/*
+data class file with/out create-site permission
+author: Samee Syed
+ */
+const utils = require('../../common/utils')
+
+const createSite = {
+    "name": utils.getRandomString(5),
+    "alias": utils.getRandomString(5),
+    "parentSiteId": "",
+    "siteType": "REGION"
+}
+
+module.exports = {
+    createSite
+}

--- a/api-tests/specs/createTrialSite/createNewTrialSite.js
+++ b/api-tests/specs/createTrialSite/createNewTrialSite.js
@@ -1,123 +1,196 @@
+/*
+create New Trial class file that has scenarios to run create-site tests with authorizations
+author - Samee Syed
+*/
 const requests = require('../../data/createTrialSite/createNewTrialSite')
 const conf = require('../../config/conf')
 const endpointUri = '/api/sites';
+const utils = require('../../common/utils')
+const fetch = require("node-fetch");
 let ccoParentSiteId;
 let rccParentSiteId;
 let countryParentSiteId;
 
 describe('As a user with Create Trial Sites permission I want to have the system constrain the type of trial site I can add as a child of an existing trial site and enforce validation rules defined for the site type so that I can ensure the integrity of the trial site structure meets the needs of my trial', function () {
 
-    it('GIVEN I have Trial Site Type fields and site structure rules defined AND I DO NOT have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN a new Trial site record is created in the system, a unique identifier for itself and an acknowledgement is returned', async () => {
-
-        const getSitesResponse = await baseRequest.get(endpointUri);
-        const captureParentSiteId = getSitesResponse.text
-        let parseParentSiteIdData = JSON.parse(captureParentSiteId)
-        ccoParentSiteId = parseParentSiteIdData[0].siteId
+    //sending a  GET request to view CCO site ID
+    it.only('GIVEN I have Trial Site Type fields(Viewing CCO) and site structure rules defined AND I DO NOT have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN a new Trial site record is created in the system, a unique identifier for itself and an acknowledgement is returned', async () => {
+        const headers1 = await utils.getHeadersWithAuth()
+        let fetchResponse1 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers1,
+            method: 'GET',
+        })
+        let ParentSiteIdData = await fetchResponse1.json();
+        ccoParentSiteId = ParentSiteIdData[0].siteId
+        expect(fetchResponse1.status).to.equal(HttpStatus.OK)
     });
 
-    it('GIVEN I have Trial Site Type fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
+    //POST a request to create RCC
+    it.only('GIVEN I have Trial Site Type (Region creatin) fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
         let ccoAsParent = requests.validSiteRCC;
         ccoAsParent.parentSiteId = ccoParentSiteId
-        const rccResponseId = await baseRequest.post(endpointUri).send(ccoAsParent);
-        expect(rccResponseId.status).to.equal(HttpStatus.CREATED)
-        const captureRCCParentSiteResponseData = rccResponseId.text
-        let parseRCCParentSiteResponseData = JSON.parse(captureRCCParentSiteResponseData)
-        rccParentSiteId = parseRCCParentSiteResponseData.id
-        console.log('rcc site id' + parseRCCParentSiteResponseData.id)
+        const headers2 = await utils.getHeadersWithAuth()
+        let fetchResponse2 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers2,
+            method: 'POST',
+            body: JSON.stringify(ccoAsParent),
+        })
+        let regionResponse = await fetchResponse2.json();
+        expect(fetchResponse2.status).to.equal(HttpStatus.CREATED)
+        rccParentSiteId = regionResponse.id
     });
 
-    it('GIVEN I have Trial Site Type fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
+    //POST a request to create COUNTRY
+    it.only('GIVEN I have Trial Site Type (Country creation) fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
         let rccAsParent = requests.validSiteCountry;
         rccAsParent.parentSiteId = rccParentSiteId
-        const countryResponseId = await baseRequest.post(endpointUri).send(rccAsParent);
-        expect(countryResponseId.status).to.equal(HttpStatus.CREATED)
-        const captureCountryParentSiteResponseData = countryResponseId.text
-        let parseCountryParentSiteResponseData = JSON.parse(captureCountryParentSiteResponseData)
-        countryParentSiteId = parseCountryParentSiteResponseData.id
+        const headers3 = await utils.getHeadersWithAuth()
+        let fetchResponse3 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers3,
+            method: 'POST',
+            body: JSON.stringify(rccAsParent),
+        })
+        let countryResponse = await fetchResponse3.json();
+        expect(fetchResponse3.status).to.equal(HttpStatus.CREATED)
+        countryParentSiteId = countryResponse.id
     });
 
-    it('GIVEN I have Trial Site Type fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
+    //POST a request to create LCC
+    it.only('GIVEN I have Trial Site Type(LCC creation) fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
         let countryAsParent = requests.validSiteLCC
         countryAsParent.parentSiteId = countryParentSiteId
-        const lccResponseId = await baseRequest.post(endpointUri).send(countryAsParent);
-        expect(lccResponseId.status).to.equal(HttpStatus.CREATED)
+        const headers4 = await utils.getHeadersWithAuth()
+        let fetchResponse4 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers4,
+            method: 'POST',
+            body: JSON.stringify(countryAsParent),
+        })
+        expect(fetchResponse4.status).to.equal(HttpStatus.CREATED)
     });
 
-    it('WHEN I submit an API request to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
+    //attempting to create an RCC with missing Name using POST
+    it.only('WHEN I submit an API request (Name missing)to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
         let missingNameRccAsParent = requests.missingName;
         missingNameRccAsParent.parentSiteId = ccoParentSiteId
-        const response = await baseRequest.post(endpointUri).send(missingNameRccAsParent);
-        expect(response.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
+        const headers5 = await utils.getHeadersWithAuth()
+        let fetchResponse5 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers5,
+            method: 'POST',
+            body: JSON.stringify(missingNameRccAsParent),
+        })
+        expect(fetchResponse5.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
     });
 
-    it('WHEN I submit an API request to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
+    //attempting to create an RCC with missing Alias using POST
+    it.only('WHEN I submit an API request (Alias missing) to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
         let missingAliasRccAsParent = requests.missingAlias;
         missingAliasRccAsParent.parentSiteId = ccoParentSiteId
-        const response = await baseRequest.post(endpointUri).send(missingAliasRccAsParent);
-        expect(response.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
+        const headers6 = await utils.getHeadersWithAuth()
+        let fetchResponse6 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers6,
+            method: 'POST',
+            body: JSON.stringify(missingAliasRccAsParent),
+        })
+        expect(fetchResponse6.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
+        //+correctly displayed as 422:UNPROCESSABLE_ENTITY if manually run in POSTMAN
     });
 
-    it('WHEN I submit an API request to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
+    //attempting to create an RCC with missing Name and Alias using POST
+    it.only('WHEN I submit an API request(Name & Alias missing) to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
         let missingBothRccAsParent = requests.missingBoth;
         missingBothRccAsParent.parentSiteId = ccoParentSiteId
-        const response = await baseRequest.post(endpointUri).send(missingBothRccAsParent);
-        expect(response.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
+        const headers7 = await utils.getHeadersWithAuth()
+        let fetchResponse7 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers7,
+            method: 'POST',
+            body: JSON.stringify(missingBothRccAsParent),
+        })
+        expect(fetchResponse7.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
     });
 
-    it('WHEN I submit an API request to create a Trial site with any fields exceeding their specified maximum length, THEN AC3 a new record is not created and I receive an error notification', async () => {
+    //attempting to create an RCC with Name exceeding permitted character count using POST
+    it.only('WHEN I submit an API request (Name exceeding) to create a Trial site with any fields exceeding their specified maximum length, THEN AC3 a new record is not created and I receive an error notification', async () => {
         let exceedingNameRccAsParent = requests.exceedingName;
         exceedingNameRccAsParent.parentSiteId = ccoParentSiteId
-        const response = await baseRequest.post(endpointUri).send(requests.exceedingNameRccAsParent);
-        expect(response.status).to.equal(HttpStatus.BAD_REQUEST)
+        const headers8 = await utils.getHeadersWithAuth()
+        let fetchResponse8 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers8,
+            method: 'POST',
+            body: JSON.stringify(exceedingNameRccAsParent),
+        })
+        expect(fetchResponse8.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
     });
 
-    it('WHEN I submit an API request to create a Trial site with any fields exceeding their specified maximum length, THEN AC3 a new record is not created and I receive an error notification', async () => {
+    //attempting to create an RCC with Alias exceeding permitted character count using POST
+    it.only('WHEN I submit an API request (Alias exceeding) to create a Trial site with any fields exceeding their specified maximum length, THEN AC3 a new record is not created and I receive an error notification', async () => {
         let exceedingAliasRccAsParent = requests.exceedingAlias;
         exceedingAliasRccAsParent.parentSiteId = ccoParentSiteId
-        const response = await baseRequest.post(endpointUri).send(requests.exceedingAliasRccAsParent);
-        expect(response.status).to.equal(HttpStatus.BAD_REQUEST)
+        const headers9 = await utils.getHeadersWithAuth()
+        let fetchResponse9 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers9,
+            method: 'POST',
+            body: JSON.stringify(exceedingAliasRccAsParent),
+        })
+        expect(fetchResponse9.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
     });
 
-    it('WHEN I submit an API request to create a Trial site with any fields exceeding their specified maximum length, THEN AC3 a new record is not created and I receive an error notification', async () => {
+    //attempting to create an RCC with Name and Alias exceeding permitted character count using POST
+    it.only('WHEN I submit an API (Name & Alias exceeding) request to create a Trial site with any fields exceeding their specified maximum length, THEN AC3 a new record is not created and I receive an error notification', async () => {
         let exceedingBothRccAsParent = requests.exceedingBoth;
         exceedingBothRccAsParent.parentSiteId = ccoParentSiteId
-        const response = await baseRequest.post(endpointUri).send(requests.exceedingBothRccAsParent);
-        expect(response.status).to.equal(HttpStatus.BAD_REQUEST)
+        const headers10 = await utils.getHeadersWithAuth()
+        let fetchResponse10 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers10,
+            method: 'POST',
+            body: JSON.stringify(exceedingBothRccAsParent),
+        })
+        expect(fetchResponse10.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
     });
 
-    it('WHEN I submit an API request to create a Trial site without specifying the parent trial site THEN AC4 a new record is not created and I receive an error notification', async () => {
-        const response = await baseRequest.post(endpointUri).send(requests.missingParent);
-        expect(response.status).to.equal(HttpStatus.INTERNAL_SERVER_ERROR)
+    //attempting to create an RCC with missing parentSiteId using POST
+    it.only('WHEN I submit an API request to create a Trial site without specifying the parent trial site THEN AC4 a new record is not created and I receive an error notification', async () => {
+        const headers11 = await utils.getHeadersWithAuth()
+        let fetchResponse11 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers11,
+            method: 'POST',
+            body: JSON.stringify(requests.missingParent),
+        })
+        expect(fetchResponse11.status).to.equal(HttpStatus.FORBIDDEN)
     });
 
-    it('WHEN I submit an API request to create a Trial site with an invalid parent ‘type’ trial site THEN AC5 a new record is not created and I receive an error notification', async () => {
-        const response = await baseRequest.post(endpointUri).send(requests.invalidParentType);
-        expect(response.status).to.equal(HttpStatus.INTERNAL_SERVER_ERROR)
+    //attempting to create an RCC with missing invalidSiteType using POST
+    it.only('WHEN I submit an API request to create a Trial site with an invalid parent ‘type’ trial site THEN AC5 a new record is not created and I receive an error notification', async () => {
+        let invalidSiteTypeRccAsParent = requests.invalidSiteType;
+        invalidSiteTypeRccAsParent.parentSiteId = ccoParentSiteId
+        const headers12 = await utils.getHeadersWithAuth()
+        let fetchResponse12 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers12,
+            method: 'POST',
+            body: JSON.stringify(invalidSiteTypeRccAsParent),
+        })
+        expect(fetchResponse12.status).to.equal(HttpStatus.INTERNAL_SERVER_ERROR)
     });
 
-    it('WHEN I submit an API request to create a Trial site and do not provide a unique name THEN AC6 a new record is not created and I receive an error notification', async () => {
-        let duplicateNameRccAsParent = requests.duplicateName;
-        duplicateNameRccAsParent.parentSiteId = ccoParentSiteId
-        const response = await baseRequest.post(endpointUri).send(requests.duplicateNameRccAsParent);
-        expect(response.status).to.equal(HttpStatus.BAD_REQUEST)
+    //attempting to create an RCC with duplicate Name using POST
+    it.only('WHEN I submit an API request to create a Trial site and do not provide a unique name THEN AC6 a new record is not created and I receive an error notification', async () => {
+        const headers13 = await utils.getHeadersWithAuth()
+        let fetchResponse13 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers13,
+            method: 'POST',
+            body: JSON.stringify(requests.duplicateName),
+        })
+        expect(fetchResponse13.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
     });
 
-    it('WHEN I submit an API request to create a Trial site and do not provide a unique alias THEN AC6 a new record is not created and I receive an error notification', async () => {
-        let duplicateAliasRccAsParent = requests.duplicateAlias;
-        duplicateAliasRccAsParent.parentSiteId = ccoParentSiteId
-        const response = await baseRequest.post(endpointUri).send(requests.duplicateAliasRccAsParent);
-        expect(response.status).to.equal(HttpStatus.BAD_REQUEST)
-    });
-
-    it('WHEN I submit an API request to create a Trial site and do not provide a unique alias THEN AC6 a new record is not created and I receive an error notification', async () => {
-        let duplicateBothRccAsParent = requests.duplicateBoth;
-        duplicateBothRccAsParent.parentSiteId = ccoParentSiteId
-        const response = await baseRequest.post(endpointUri).send(requests.duplicateBothRccAsParent);
-        expect(response.status).to.equal(HttpStatus.BAD_REQUEST)
-    });
-
-    it('WHEN a entry to create new trial site is successfully recorded THEN the user can examine its existence by sending a Get request', async () => {
-        const response = await baseRequest.get(endpointUri)
-        expect(response.status).to.equal(HttpStatus.OK)
-    });
+    //attempting to view the created trial site using Get
+    it.only('WHEN a entry to create new trial site is successfully recorded THEN the user can examine its existence by sending a Get request', async () => {
+        const headers14 = await utils.getHeadersWithAuth()
+        let fetchResponse14 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers14,
+            method: 'GET',
+        })
+        let sitesResponse = await fetchResponse14.json();
+        ccoParentSiteId = sitesResponse[0].siteId
+        expect(fetchResponse14.status).to.equal(HttpStatus.OK)
+    })
 });

--- a/api-tests/specs/createTrialSite/createNewTrialSite.js
+++ b/api-tests/specs/createTrialSite/createNewTrialSite.js
@@ -173,13 +173,20 @@ describe('As a user with Create Trial Sites permission I want to have the system
 
     //attempting to create an RCC with duplicate Name using POST
     it.only('WHEN I submit an API request to create a Trial site and do not provide a unique name THEN AC6 a new record is not created and I receive an error notification', async () => {
+        let duplicateNameRequest = requests.duplicateName;
+        duplicateNameRequest.parentSiteId = ccoParentSiteId
         const headers13 = await utils.getHeadersWithAuth()
         let fetchResponse13 = await fetch(conf.baseUrl + endpointUri, {
             headers: headers13,
             method: 'POST',
-            body: JSON.stringify(requests.duplicateName),
+            body: JSON.stringify(duplicateNameRequest),
         })
-        expect(fetchResponse13.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
+        let fetchResponse22 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers13,
+            method: 'POST',
+            body: JSON.stringify(duplicateNameRequest),
+        })
+        expect(fetchResponse22.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY)
     });
 
     //attempting to view the created trial site using Get

--- a/api-tests/specs/createTrialSite/createSitePermissions.js
+++ b/api-tests/specs/createTrialSite/createSitePermissions.js
@@ -1,0 +1,56 @@
+/*
+Create New Trial Sites class file that contain scenarios covering create site entities
+author: Samee Syed
+*/
+const requests = require('../../data/createTrialSite/createSitePermission')
+const conf = require('../../config/conf')
+const endpointUri = '/api/sites';
+const utils = require('../../common/utils')
+const fetch = require("node-fetch");
+let ccoParentSiteId;
+
+describe('As a Chief Investigator I want all requests to create Trial Sites authorised so that only users with the required permission can create Trial Sites in the part of the tree they have permission to update', function () {
+
+    // sending a GET request to view CCO site ID as a superuser
+    it('User should be able to view existing node site', async () => {
+        const headers1 = await utils.getHeadersWithAuth()
+        let fetchResponse1 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers1,
+            method: 'GET',
+        })
+        let ParentSiteIdData = await fetchResponse1.json();
+        ccoParentSiteId = ParentSiteIdData[0].siteId
+        expect(fetchResponse1.status).to.equal(HttpStatus.OK)
+    });
+
+    //sending a POST request with create-site permission(superuser-bootstrap user)
+    it('User can create new trial site with create-site permission', async () => {
+        let ccoAsParent = requests.createSite;
+        ccoAsParent.parentSiteId = ccoParentSiteId
+        const headers2 = await utils.getHeadersWithAuth()
+        let fetchResponse2 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers2,
+            method: 'POST',
+            body: JSON.stringify(ccoAsParent),
+        })
+        let regionResponse = await fetchResponse2.json();
+        expect(fetchResponse2.status).to.equal(HttpStatus.CREATED)
+        rccParentSiteId = regionResponse.id
+    });
+
+    // attempting to create a site WITHOUT create-site permission (admin-qa create)
+    // Sending a POST request
+    it('User cannot create new trial site without create-site permission', async () => {
+        let ccoAsParent = requests.createSite;
+        ccoAsParent.parentSiteId = ccoParentSiteId
+        const headers3 = await utils.qaHeadersWithAuth()
+        //  console.log('this is the token id' + JSON.stringify(headers3))
+        let fetchResponse3 = await fetch(conf.baseUrl + endpointUri, {
+            headers: headers3,
+            method: 'POST',
+            body: JSON.stringify(ccoAsParent),
+        })
+        console.log('some text' + JSON.stringify(conf.baseUrl + endpointUri))
+        expect(fetchResponse3.status).to.equal(HttpStatus.FORBIDDEN)
+    });
+});


### PR DESCRIPTION
## Description
Automated API tests for create-site with auth feature

### Changes
- [ARTS-622] - Automated API tests

### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR


[ARTS-622]: https://ndph-arts.atlassian.net/browse/ARTS-622