### PR TITLE
[fix] Allow access /actuator/health without any auth

### DIFF
--- a/security/src/main/java/uk/ac/ox/ndph/mts/security/authentication/AADWebSecurityConfig.java
+++ b/security/src/main/java/uk/ac/ox/ndph/mts/security/authentication/AADWebSecurityConfig.java
@@ -35,6 +35,7 @@ public class AADWebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     /**
      * Http security configuration
+     *
      * @param http - http security
      * @throws Exception - general exception
      */
@@ -50,6 +51,7 @@ public class AADWebSecurityConfig extends WebSecurityConfigurerAdapter {
 
         // This requires all requests to have a valid token
         http.authorizeRequests() //NOSONAR
+                .antMatchers("/actuator/health").permitAll() // allow health check without AuthN
                 .anyRequest().authenticated();
 
         // This enables us to return appropriate http codes


### PR DESCRIPTION
## Description
Health checks endpoints should allow access without any authNZ

### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
