### PR TITLE
[ARTS-884] Validate configuration classes

### DIFF
--- a/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/model/Practitioner.java
+++ b/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/model/Practitioner.java
@@ -1,5 +1,6 @@
 package uk.ac.ox.ndph.mts.init_service.model;
 
+import javax.validation.constraints.NotBlank;
 import java.util.List;
 
 /**
@@ -8,10 +9,11 @@ import java.util.List;
 public class Practitioner implements Entity {
 
     private String prefix;
+    @NotBlank
     private String givenName;
+    @NotBlank
     private String familyName;
-    private List<String> roles;
-
+    private List<@NotBlank String> roles;
     private String userAccount;
 
     public String getPrefix() {

--- a/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/model/Site.java
+++ b/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/model/Site.java
@@ -1,9 +1,15 @@
 package uk.ac.ox.ndph.mts.init_service.model;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+
 public class Site implements Entity {
+    @NotBlank
     private String name;
     private String alias;
+    @NotBlank
     private String siteType;
+    @Valid
     private SiteAddress address;
 
     public String getName() {

--- a/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/model/Trial.java
+++ b/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/model/Trial.java
@@ -3,17 +3,26 @@ package uk.ac.ox.ndph.mts.init_service.model;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 import uk.ac.ox.ndph.mts.roleserviceclient.model.RoleDTO;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import java.util.List;
 
 @Component
 @Configuration
+@Validated
 @ConfigurationProperties("mts.trial")
 public class Trial {
-    private List<Practitioner> persons;
-    private List<Site> sites;
-    private List<RoleDTO> roles;
+    @NotEmpty
+    private List<@Valid Practitioner> persons;
+    @NotEmpty
+    private List<@Valid Site> sites;
+    @NotEmpty
+    private List<@Valid RoleDTO> roles;
+    @NotBlank
     private String trialName;
 
     public List<Practitioner> getPersons() {

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/model/PractitionerAttributeConfiguration.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/model/PractitionerAttributeConfiguration.java
@@ -1,16 +1,12 @@
 package uk.ac.ox.ndph.mts.practitioner_service.model;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import javax.validation.constraints.NotBlank;
 
-
-@Configuration
-@ConfigurationProperties(prefix = "attributes")
-@EnableConfigurationProperties
 public class PractitionerAttributeConfiguration {
 
+    @NotBlank
     private String name;
+    @NotBlank
     private String displayName;
     private String validationRegex;
 
@@ -32,20 +28,20 @@ public class PractitionerAttributeConfiguration {
         return name;
     }
 
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public String getValidationRegex() {
-        return validationRegex;
-    }
-
     public void setName(String name) {
         this.name = name;
     }
 
+    public String getDisplayName() {
+        return displayName;
+    }
+
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
+    }
+
+    public String getValidationRegex() {
+        return validationRegex;
     }
 
     public void setValidationRegex(String validationRegex) {

--- a/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/model/PractitionerConfiguration.java
+++ b/practitioner-service/src/main/java/uk/ac/ox/ndph/mts/practitioner_service/model/PractitionerConfiguration.java
@@ -1,21 +1,29 @@
 package uk.ac.ox.ndph.mts.practitioner_service.model;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+@Component
 @Configuration
+@Validated
 @ConfigurationProperties(prefix = "mts.practitioner")
-@EnableConfigurationProperties
 public class PractitionerConfiguration {
 
+    @NotBlank
     private String name;
+    @NotBlank
     private String displayName;
-    private List<PractitionerAttributeConfiguration> attributes;
+    @NotEmpty
+    private List<@Valid PractitionerAttributeConfiguration> attributes;
 
     public PractitionerConfiguration() {
         this.name = "";
@@ -35,23 +43,23 @@ public class PractitionerConfiguration {
         return Collections.unmodifiableCollection(attributes);
     }
 
-    public String getName() {
-        return name;
+    public void setAttributes(List<PractitionerAttributeConfiguration> attributes) {
+        this.attributes = attributes;
     }
 
-    public String getDisplayName() {
-        return displayName;
+    public String getName() {
+        return name;
     }
 
     public void setName(String name) {
         this.name = name;
     }
 
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
+    public String getDisplayName() {
+        return displayName;
     }
 
-    public void setAttributes(List<PractitionerAttributeConfiguration> attributes) {
-        this.attributes = attributes;
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
     }
 }

--- a/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/controller/PractitionerControllerTests.java
+++ b/practitioner-service/src/test/java/uk/ac/ox/ndph/mts/practitioner_service/controller/PractitionerControllerTests.java
@@ -2,7 +2,6 @@ package uk.ac.ox.ndph.mts.practitioner_service.controller;
 
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -43,7 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @SpringBootTest(properties = {"spring.cloud.config.discovery.enabled = false", "spring.cloud.config.enabled=false", "server.error.include-message=always", "spring.main.allow-bean-definition-overriding=true"})
-@ActiveProfiles({"no-authZ", "test-all-required"})
+@ActiveProfiles({"test-all-required", "local", "no-authZ"})
 @AutoConfigureMockMvc
 class PractitionerControllerTests {
 

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/AddressConfiguration.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/AddressConfiguration.java
@@ -3,7 +3,9 @@ package uk.ac.ox.ndph.mts.site_service.model;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
+import javax.validation.Valid;
 import java.util.List;
 
 /**
@@ -11,6 +13,7 @@ import java.util.List;
  */
 @Component
 @Configuration
+@Validated
 @ConfigurationProperties("mts.address")
 public class AddressConfiguration {
 
@@ -31,7 +34,7 @@ public class AddressConfiguration {
         this.addressType = addressType;
     }
 
-    private List<SiteAttributeConfiguration> addressType;
+    private List<@Valid SiteAttributeConfiguration> addressType;
 
     /**
      * Returns the attributes associated with the SiteConfiguration.

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/SiteAttributeConfiguration.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/SiteAttributeConfiguration.java
@@ -2,14 +2,18 @@ package uk.ac.ox.ndph.mts.site_service.model;
 
 import org.springframework.stereotype.Component;
 
+import javax.validation.constraints.NotBlank;
+
 /**
  * Site Attribute configuration Model
  */
 @Component
 public class SiteAttributeConfiguration {
 
+    @NotBlank
     private String name;
     private String type;
+    @NotBlank
     private String displayName;
     private String validationRegex;
 
@@ -22,9 +26,9 @@ public class SiteAttributeConfiguration {
     /**
      * Constructor with all members initialized, no validation checks here
      *
-     * @param name            attribute name can be null
-     * @param type            atttribute type can be null
-     * @param displayName     atttribute display name can be null
+     * @param name attribute name can be null
+     * @param type atttribute type can be null
+     * @param displayName atttribute display name can be null
      * @param validationRegex for regexc-based validation, can be null
      */
     public SiteAttributeConfiguration(final String name, final String type,

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/SiteConfiguration.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/SiteConfiguration.java
@@ -3,7 +3,11 @@ package uk.ac.ox.ndph.mts.site_service.model;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import java.util.List;
 
 /**
@@ -11,6 +15,7 @@ import java.util.List;
  */
 @Component
 @Configuration
+@Validated
 @ConfigurationProperties("mts.site")
 public class SiteConfiguration {
 
@@ -43,12 +48,16 @@ public class SiteConfiguration {
         this.child = child;
     }
 
+    @NotBlank
     private String name;
+    @NotBlank
     private String displayName;
+    @NotBlank
     private String type;
-    private List<SiteAttributeConfiguration> attributes;
-    private List<SiteAttributeConfiguration> custom;
-    private List<SiteConfiguration> child;
+    @NotEmpty
+    private List<@Valid SiteAttributeConfiguration> attributes;
+    private List<@Valid SiteAttributeConfiguration> custom;
+    private List<@Valid SiteConfiguration> child;
 
     /**
      * Returns the name associated with the SiteConfiguration.

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/SiteServiceImplIntegrationTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/SiteServiceImplIntegrationTests.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
@@ -31,18 +32,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(properties = { "spring.cloud.config.discovery.enabled = false" , "spring.cloud.config.enabled=false", "server.error.include-message=always", "spring.main.allow-bean-definition-overriding=true", "fhir.uri=http://localhost:8099","role.service.uri=http://role-service:8082" })
-@ActiveProfiles({"no-authZ", "test-all-required"})
+@SpringBootTest(properties = {"spring.cloud.config.discovery.enabled = false", "spring.cloud.config.enabled=false", "server.error.include-message=always", "spring.main.allow-bean-definition-overriding=true", "fhir.uri=http://localhost:8099", "role.service.uri=http://role-service:8082"})
+@ActiveProfiles({"no-authZ"})
 @AutoConfigureMockMvc
+@Import(TestSiteConfiguration.class)
 class SiteServiceImplIntegrationTests {
 
     private static final String SITES_ROUTE = "/sites";
-
-    @Autowired
-    private MockMvc mockMvc;
-
     @MockBean
     public FhirRepository repository;
+    @Autowired
+    private MockMvc mockMvc;
 
     @WithMockUser
     @Test

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/TestSiteConfiguration.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/TestSiteConfiguration.java
@@ -1,39 +1,34 @@
 package uk.ac.ox.ndph.mts.site_service;
 
-import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Profile;
 import uk.ac.ox.ndph.mts.site_service.model.SiteAttributeConfiguration;
 import uk.ac.ox.ndph.mts.site_service.model.SiteConfiguration;
 
 import java.util.Collections;
 import java.util.List;
 
-@Profile("test-all-required")
-@SpringBootConfiguration
+@TestConfiguration
 public class TestSiteConfiguration {
-    
+
     private static final List<SiteAttributeConfiguration> ALL_REQUIRED_UNDER_35_MAP = List.of(
-        new SiteAttributeConfiguration("name", "string", "Name", "^[a-zA-Z]{1,35}$"),
-        new SiteAttributeConfiguration("alias", "string","Alias", "^[a-zA-Z]{1,35}$"),
-        new SiteAttributeConfiguration("parentSiteId", "string","Parent Site Id", ""),
-        new SiteAttributeConfiguration("siteType","string", "Site Type", ""));
+            new SiteAttributeConfiguration("name", "string", "Name", "^[a-zA-Z]{1,35}$"),
+            new SiteAttributeConfiguration("alias", "string", "Alias", "^[a-zA-Z]{1,35}$"),
+            new SiteAttributeConfiguration("parentSiteId", "string", "Parent Site Id", ""),
+            new SiteAttributeConfiguration("siteType", "string", "Site Type", ""));
 
     private static final List<SiteAttributeConfiguration> ALL_REQUIRED_UNDER_35_MAP_CUSTOM = List.of(
             new SiteAttributeConfiguration("address", "address", "Address", ""));
 
 
-    private static final List<SiteConfiguration> SITE_CONFIGURATION_LIST  = List.of(
+    private static final List<SiteConfiguration> SITE_CONFIGURATION_LIST = List.of(
             new SiteConfiguration("Organization", "site", "REGION", ALL_REQUIRED_UNDER_35_MAP, null,
                     Collections.singletonList(new SiteConfiguration("Organization", "site", "COUNTRY", ALL_REQUIRED_UNDER_35_MAP, null,
                             Collections.singletonList(new SiteConfiguration("Organization", "site", "LCC", ALL_REQUIRED_UNDER_35_MAP, ALL_REQUIRED_UNDER_35_MAP_CUSTOM, null)
                             )))));
 
-    // use this site config for all tests unless they define their own one
-    @Primary
     @Bean
-    public SiteConfiguration getSiteConfiguration() {
+    public SiteConfiguration siteConfiguration() {
         return new SiteConfiguration("site",
                 "Site", "CCO", ALL_REQUIRED_UNDER_35_MAP, ALL_REQUIRED_UNDER_35_MAP_CUSTOM, SITE_CONFIGURATION_LIST);
     }

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/controller/SiteControllerTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/controller/SiteControllerTests.java
@@ -5,10 +5,8 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -20,7 +18,6 @@ import uk.ac.ox.ndph.mts.site_service.exception.InvariantException;
 import uk.ac.ox.ndph.mts.site_service.exception.RestException;
 import uk.ac.ox.ndph.mts.site_service.exception.ValidationException;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
-import uk.ac.ox.ndph.mts.site_service.model.SiteConfiguration;
 import uk.ac.ox.ndph.mts.site_service.service.SiteService;
 
 import java.util.Collections;
@@ -40,6 +37,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(properties = {"spring.cloud.config.discovery.enabled = false", "spring.cloud.config.enabled=false", "server.error.include-message=always", "spring.main.allow-bean-definition-overriding=true", "fhir.uri=http://localhost:8099", "role.service.uri=http://role-service:8082"})
 @ActiveProfiles("no-authZ")
 @AutoConfigureMockMvc
+// Tests don't need actual config, but have to use it because we prepare an application context
+@Import(TestSiteConfiguration.class)
 class SiteControllerTests {
 
     private static final String SITES_ROUTE = "/sites";
@@ -49,17 +48,6 @@ class SiteControllerTests {
 
     @MockBean
     private SiteService siteService;
-
-    @TestConfiguration
-    static class Config {
-        private final TestSiteConfiguration configuration = new TestSiteConfiguration();
-
-        @Primary
-        @Bean
-        public SiteConfiguration getSiteConfiguration() {
-            return configuration.getSiteConfiguration();
-        }
-    }
 
     @WithMockUser
     @Test


### PR DESCRIPTION
## Description
This PR adds validation on the java classes themselves and results in detailed errors on load time if the fetched config doesn't fit the classes (rather than just dependency injection errors like before).

### Changes
- [ARTS-884] - Config classes validation

### Checklist:

- [x] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-884]: https://ndph-arts.atlassian.net/browse/ARTS-884