### PR TITLE
[ARTS-382] Depend on build not test for nightly deploy

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -208,7 +208,7 @@ jobs:
   deploy_nightly:
     name: Deploy nightly image
     if: github.ref == 'refs/heads/main' && github.event_name == 'schedule'
-    needs: test
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Deploy main-nightly image


### PR DESCRIPTION
## Description
Run nightly deploy after build not test

### Changes
- [ARTS-382] - some description

### Checklist:

- [x] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-382]: https://ndph-arts.atlassian.net/browse/ARTS-382