### PR TITLE
[fix] Remove obsolete properties file

### DIFF
--- a/role-service/src/main/resources/application.properties
+++ b/role-service/src/main/resources/application.properties
@@ -1,9 +1,0 @@
-spring.liquibase.change-log=classpath:/db/changelog/changelog-role-service-master.xml
-spring.liquibase.drop-first=false
-spring.liquibase.enabled=true
-spring.jpa.hibernate.ddl-auto=none
-spring.hateoas.use-hal-as-default-json-media-type=false
-server.error.include-message = always
-server.error.include-binding-errors=always
-
-


### PR DESCRIPTION
## Description
Remove an obsolete properties file from the role-service, which anyway isn't taking affect since the exact same properties are coming from the config-server and cannot be overridden (be default)

### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
