### PR TITLE
[ARTS-764] - API tests on Role Assignment URI

### DIFF
--- a/api-tests/specs/assign-roles/assign-roles.js
+++ b/api-tests/specs/assign-roles/assign-roles.js
@@ -9,7 +9,9 @@ const sitesEndpointUri = '/api/sites';
 const rolesEndpointUri = '/api/roles';
 const profileEndpointUri = '/api/practitioner/profile'
 const practitionerEndpointUri = '/api/practitioner'
-let assignRoleEndpointUri = '/api/practitioner/{profileId}/roles'
+const assignRoleEndpointUri = '/api/practitioner/{profileId}/roles'
+const roleAssigEndpointUri = '/api/practitioner/roles?userIdentity=5d995fd0-a1ff-4b2c-ba93-238ba9e349b1'
+const invalidRoleAssigEndpointUri = '/api/practitioner/roles?userIdentity=f4c3120a-1ca4-4b59-ab6d-e362016f68fb'
 const utils = require('../../common/utils')
 const fetch = require("node-fetch");
 let ccoParentSiteId;
@@ -252,5 +254,26 @@ describe('As a user with Assign Roles permission and authorisation I want to ass
         expect(fetchResponse16.status).to.equal(HttpStatus.FORBIDDEN)
     });
 
+});
 
+describe('As a user I should be able to validate Get the roles assigned to me is done by the same user asking for the Roles and validate Get my roles permissions is done by the same user asking for the permissions.', function () {
+
+    it('AC001 - When the user by identity request is identical to the user by token then request Get Assignment Roles is done, the request is completed successfully', async () => {
+
+        const headers = await utils.getBootStrapUserHeadersWithAuth()
+        let fetchResponse = await fetch(conf.baseUrl + roleAssigEndpointUri, {
+            headers: headers,
+            method: 'GET',
+        })
+        expect(fetchResponse.status).to.equal(HttpStatus.OK)
+    });
+
+    it('AC003 - When the user by identity request is not identical to the user by token then the request Get Assignment Roles is done, the request is failed due not identical user', async () => {
+        const headers1 = await utils.getBootStrapUserHeadersWithAuth()
+        let fetchResponse1 = await fetch(conf.baseUrl + invalidRoleAssigEndpointUri, {
+            headers: headers1,
+            method: 'GET',
+        })
+        expect(fetchResponse1.status).to.equal(HttpStatus.FORBIDDEN)
+    });
 });

--- a/api-tests/specs/createTrialSite/createNewTrialSite.js
+++ b/api-tests/specs/createTrialSite/createNewTrialSite.js
@@ -14,7 +14,7 @@ let countryParentSiteId;
 describe('As a user with Create Trial Sites permission I want to have the system constrain the type of trial site I can add as a child of an existing trial site and enforce validation rules defined for the site type so that I can ensure the integrity of the trial site structure meets the needs of my trial', function () {
 
     //sending a  GET request to view CCO site ID
-    it.only('GIVEN I have Trial Site Type fields(Viewing CCO) and site structure rules defined AND I DO NOT have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN a new Trial site record is created in the system, a unique identifier for itself and an acknowledgement is returned', async () => {
+    it('GIVEN I have Trial Site Type fields(Viewing CCO) and site structure rules defined AND I DO NOT have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN a new Trial site record is created in the system, a unique identifier for itself and an acknowledgement is returned', async () => {
         const headers1 = await utils.getHeadersWithAuth()
         let fetchResponse1 = await fetch(conf.baseUrl + endpointUri, {
             headers: headers1,
@@ -26,7 +26,7 @@ describe('As a user with Create Trial Sites permission I want to have the system
     });
 
     //POST a request to create RCC
-    it.only('GIVEN I have Trial Site Type (Region creatin) fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
+    it('GIVEN I have Trial Site Type (Region creatin) fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
         let ccoAsParent = requests.validSiteRCC;
         ccoAsParent.parentSiteId = ccoParentSiteId
         const headers2 = await utils.getHeadersWithAuth()
@@ -41,7 +41,7 @@ describe('As a user with Create Trial Sites permission I want to have the system
     });
 
     //POST a request to create COUNTRY
-    it.only('GIVEN I have Trial Site Type (Country creation) fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
+    it('GIVEN I have Trial Site Type (Country creation) fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
         let rccAsParent = requests.validSiteCountry;
         rccAsParent.parentSiteId = rccParentSiteId
         const headers3 = await utils.getHeadersWithAuth()
@@ -56,7 +56,7 @@ describe('As a user with Create Trial Sites permission I want to have the system
     });
 
     //POST a request to create LCC
-    it.only('GIVEN I have Trial Site Type(LCC creation) fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
+    it('GIVEN I have Trial Site Type(LCC creation) fields and site structure rules defined AND I have an existing trial site to act as the ‘parent’ (e.g. top node in the tree) WHEN I submit an API request to create a Trial site with a value for all mandatory fields, a unique name and a permitted parent trial site ‘type’ with no fields exceeding their specified maximum length THEN AC1 a new Trial site record is created in the system (added to the Site structure as a child of its parent) with its parent identifier, a unique identifier for itself and an acknowledgement is returned', async () => {
         let countryAsParent = requests.validSiteLCC
         countryAsParent.parentSiteId = countryParentSiteId
         const headers4 = await utils.getHeadersWithAuth()
@@ -69,7 +69,7 @@ describe('As a user with Create Trial Sites permission I want to have the system
     });
 
     //attempting to create an RCC with missing Name using POST
-    it.only('WHEN I submit an API request (Name missing)to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
+    it('WHEN I submit an API request (Name missing)to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
         let missingNameRccAsParent = requests.missingName;
         missingNameRccAsParent.parentSiteId = ccoParentSiteId
         const headers5 = await utils.getHeadersWithAuth()
@@ -82,7 +82,7 @@ describe('As a user with Create Trial Sites permission I want to have the system
     });
 
     //attempting to create an RCC with missing Alias using POST
-    it.only('WHEN I submit an API request (Alias missing) to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
+    it('WHEN I submit an API request (Alias missing) to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
         let missingAliasRccAsParent = requests.missingAlias;
         missingAliasRccAsParent.parentSiteId = ccoParentSiteId
         const headers6 = await utils.getHeadersWithAuth()
@@ -96,7 +96,7 @@ describe('As a user with Create Trial Sites permission I want to have the system
     });
 
     //attempting to create an RCC with missing Name and Alias using POST
-    it.only('WHEN I submit an API request(Name & Alias missing) to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
+    it('WHEN I submit an API request(Name & Alias missing) to create a new trial site with one or more missing mandatory fields, THEN AC2 a new record is not created and I receive an error notification', async () => {
         let missingBothRccAsParent = requests.missingBoth;
         missingBothRccAsParent.parentSiteId = ccoParentSiteId
         const headers7 = await utils.getHeadersWithAuth()
@@ -109,7 +109,7 @@ describe('As a user with Create Trial Sites permission I want to have the system
     });
 
     //attempting to create an RCC with Name exceeding permitted character count using POST
-    it.only('WHEN I submit an API request (Name exceeding) to create a Trial site with any fields exceeding their specified maximum length, THEN AC3 a new record is not created and I receive an error notification', async () => {
+    it('WHEN I submit an API request (Name exceeding) to create a Trial site with any fields exceeding their specified maximum length, THEN AC3 a new record is not created and I receive an error notification', async () => {
         let exceedingNameRccAsParent = requests.exceedingName;
         exceedingNameRccAsParent.parentSiteId = ccoParentSiteId
         const headers8 = await utils.getHeadersWithAuth()
@@ -122,7 +122,7 @@ describe('As a user with Create Trial Sites permission I want to have the system
     });
 
     //attempting to create an RCC with Alias exceeding permitted character count using POST
-    it.only('WHEN I submit an API request (Alias exceeding) to create a Trial site with any fields exceeding their specified maximum length, THEN AC3 a new record is not created and I receive an error notification', async () => {
+    it('WHEN I submit an API request (Alias exceeding) to create a Trial site with any fields exceeding their specified maximum length, THEN AC3 a new record is not created and I receive an error notification', async () => {
         let exceedingAliasRccAsParent = requests.exceedingAlias;
         exceedingAliasRccAsParent.parentSiteId = ccoParentSiteId
         const headers9 = await utils.getHeadersWithAuth()
@@ -135,7 +135,7 @@ describe('As a user with Create Trial Sites permission I want to have the system
     });
 
     //attempting to create an RCC with Name and Alias exceeding permitted character count using POST
-    it.only('WHEN I submit an API (Name & Alias exceeding) request to create a Trial site with any fields exceeding their specified maximum length, THEN AC3 a new record is not created and I receive an error notification', async () => {
+    it('WHEN I submit an API (Name & Alias exceeding) request to create a Trial site with any fields exceeding their specified maximum length, THEN AC3 a new record is not created and I receive an error notification', async () => {
         let exceedingBothRccAsParent = requests.exceedingBoth;
         exceedingBothRccAsParent.parentSiteId = ccoParentSiteId
         const headers10 = await utils.getHeadersWithAuth()
@@ -148,7 +148,7 @@ describe('As a user with Create Trial Sites permission I want to have the system
     });
 
     //attempting to create an RCC with missing parentSiteId using POST
-    it.only('WHEN I submit an API request to create a Trial site without specifying the parent trial site THEN AC4 a new record is not created and I receive an error notification', async () => {
+    it('WHEN I submit an API request to create a Trial site without specifying the parent trial site THEN AC4 a new record is not created and I receive an error notification', async () => {
         const headers11 = await utils.getHeadersWithAuth()
         let fetchResponse11 = await fetch(conf.baseUrl + endpointUri, {
             headers: headers11,
@@ -159,7 +159,7 @@ describe('As a user with Create Trial Sites permission I want to have the system
     });
 
     //attempting to create an RCC with missing invalidSiteType using POST
-    it.only('WHEN I submit an API request to create a Trial site with an invalid parent ‘type’ trial site THEN AC5 a new record is not created and I receive an error notification', async () => {
+    it('WHEN I submit an API request to create a Trial site with an invalid parent ‘type’ trial site THEN AC5 a new record is not created and I receive an error notification', async () => {
         let invalidSiteTypeRccAsParent = requests.invalidSiteType;
         invalidSiteTypeRccAsParent.parentSiteId = ccoParentSiteId
         const headers12 = await utils.getHeadersWithAuth()
@@ -172,7 +172,7 @@ describe('As a user with Create Trial Sites permission I want to have the system
     });
 
     //attempting to create an RCC with duplicate Name using POST
-    it.only('WHEN I submit an API request to create a Trial site and do not provide a unique name THEN AC6 a new record is not created and I receive an error notification', async () => {
+    it('WHEN I submit an API request to create a Trial site and do not provide a unique name THEN AC6 a new record is not created and I receive an error notification', async () => {
         let duplicateNameRequest = requests.duplicateName;
         duplicateNameRequest.parentSiteId = ccoParentSiteId
         const headers13 = await utils.getHeadersWithAuth()
@@ -190,7 +190,7 @@ describe('As a user with Create Trial Sites permission I want to have the system
     });
 
     //attempting to view the created trial site using Get
-    it.only('WHEN a entry to create new trial site is successfully recorded THEN the user can examine its existence by sending a Get request', async () => {
+    it('WHEN a entry to create new trial site is successfully recorded THEN the user can examine its existence by sending a Get request', async () => {
         const headers14 = await utils.getHeadersWithAuth()
         let fetchResponse14 = await fetch(conf.baseUrl + endpointUri, {
             headers: headers14,

--- a/api-tests/specs/createTrialSite/createSitePermissions.js
+++ b/api-tests/specs/createTrialSite/createSitePermissions.js
@@ -44,13 +44,11 @@ describe('As a Chief Investigator I want all requests to create Trial Sites auth
         let ccoAsParent = requests.createSite;
         ccoAsParent.parentSiteId = ccoParentSiteId
         const headers3 = await utils.qaHeadersWithAuth()
-        //  console.log('this is the token id' + JSON.stringify(headers3))
         let fetchResponse3 = await fetch(conf.baseUrl + endpointUri, {
             headers: headers3,
             method: 'POST',
             body: JSON.stringify(ccoAsParent),
         })
-        console.log('some text' + JSON.stringify(conf.baseUrl + endpointUri))
         expect(fetchResponse3.status).to.equal(HttpStatus.FORBIDDEN)
     });
 });

--- a/api-tests/specs/createTrialSite/sitesaddress.js
+++ b/api-tests/specs/createTrialSite/sitesaddress.js
@@ -24,7 +24,6 @@ describe('As a user with Create Trial Sites permission I want to create a trial 
         let response = await fetchResponse.json();
         ccoParentSiteId = response[0].siteId
         CCOData = response[0].address
-        console.log('the response message is ' + response)
         expect(CCOData).to.contain({ "address1": "address1", "address2": "address2", "address3": "address3", "address4": "address4", "address5": "address5", "city": "city", "country": "country", "postcode": "postcode" })
     });
 
@@ -52,7 +51,6 @@ describe('As a user with Create Trial Sites permission I want to create a trial 
             body: JSON.stringify(validRegionSiteId),
         })
         const validRegionSiteResponse = await fetchResponse2.json();
-        console.log('status of the response' + JSON.stringify(validRegionSiteResponse.status))
         validRegionSite = validRegionSiteResponse.id
         expect(fetchResponse2.status).to.equal(HttpStatus.CREATED)
     });


### PR DESCRIPTION
## Description
PR contains api tests written around role assignment uri. The scenarios check 

- if the user with an identical token id gets a successful response and 
- if the user with a non-identical token id gets an access denied response

### Changes
- [ARTS-764] - get my roles auth
- [ARTS-885] - Test Scenarios

### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR


[ARTS-764]: https://ndph-arts.atlassian.net/browse/ARTS-764
[ARTS-885]: https://ndph-arts.atlassian.net/browse/ARTS-885