### PR TITLE
Feature/arts 774 admin trial sites

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,6 @@ services:
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
       LOGGING_LEVEL_ROOT: ${LOGGING_LEVEL_ROOT:-INFO}
-      JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
     healthcheck:
       test: curl --fail http://localhost:8083/actuator/health
       interval: 10s
@@ -87,7 +86,6 @@ services:
       retries: 6 # a quick service
     ports:
       - "8083:8083"
-      - "5005:5005"
 
   #######################
   # SUPPORTING SERVICES #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
       LOGGING_LEVEL_ROOT: ${LOGGING_LEVEL_ROOT:-INFO}
+      JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
     healthcheck:
       test: curl --fail http://localhost:8083/actuator/health
       interval: 10s
@@ -86,6 +87,7 @@ services:
       retries: 6 # a quick service
     ports:
       - "8083:8083"
+      - "5005:5005"
 
   #######################
   # SUPPORTING SERVICES #

--- a/init-service/src/main/resources/application-local.yml
+++ b/init-service/src/main/resources/application-local.yml
@@ -50,7 +50,19 @@ mts:
         prefix: Mr
         roles:
           - superuser
-        userAccount: some-user-account-id
+        userAccount: 5d995fd0-a1ff-4b2c-ba93-238ba9e349b1
+      - givenName: automation
+        familyName: tester
+        prefix: Mr
+        roles:
+          - superuser
+        userAccount: dc32d94e-1ade-4968-b83e-bab949b7e90c
+      - givenName: qacreate
+        familyName: qaadmin
+        prefix: Mr
+        roles:
+          - admin
+        userAccount: d4b73ba8-9d76-408b-b6e1-e3b8953b39e7
     sites:
       - name: CCO
         alias: CCO
@@ -66,6 +78,13 @@ mts:
           postcode: postcode
     roles:
       - id: superuser
+        permissions:
+          - id: create-person
+          - id: view-person
+          - id: assign-role
+          - id: create-site
+          - id: link-user
+      - id: admin
         permissions:
           - id: create-person
           - id: view-person

--- a/security/src/main/java/uk/ac/ox/ndph/mts/security/authorisation/AuthorisationService.java
+++ b/security/src/main/java/uk/ac/ox/ndph/mts/security/authorisation/AuthorisationService.java
@@ -13,6 +13,7 @@ import uk.ac.ox.ndph.mts.security.authentication.SecurityContextUtil;
 import uk.ac.ox.ndph.mts.siteserviceclient.SiteServiceClient;
 import uk.ac.ox.ndph.mts.siteserviceclient.model.SiteDTO;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -154,9 +155,10 @@ public class AuthorisationService {
     /**
      * Filter unauthorised sites
      * @param sitesReturnObject all sites returned object
+     * @param role filter sites by role
      * @return true if filtering finished successfully
      */
-    public boolean filterUserSites(List<?> sitesReturnObject) {
+    public boolean filterUserSites(List<?> sitesReturnObject, String role) {
 
         try {
             Objects.requireNonNull(sitesReturnObject, "sites can not be bull");
@@ -170,7 +172,13 @@ public class AuthorisationService {
 
             String userId = securityContextUtil.getUserId();
             String token = securityContextUtil.getToken();
-            List<RoleAssignmentDTO> roleAssignments = practitionerServiceClient.getUserRoleAssignments(userId, token);
+            List<RoleAssignmentDTO> roleAssignments =
+                new ArrayList<>(practitionerServiceClient.getUserRoleAssignments(userId, token));
+
+            if (role != null) {
+                roleAssignments.removeIf(ra -> !ra.getRoleId().equalsIgnoreCase(role));
+            }
+
             Set<String> userSites = siteUtil.getUserSites(sites, roleAssignments);
 
             sitesReturnObject.removeIf(siteObject ->

--- a/security/src/test/java/uk/ac/ox/ndph/mts/security/authorisation/AuthorisationServiceTests.java
+++ b/security/src/test/java/uk/ac/ox/ndph/mts/security/authorisation/AuthorisationServiceTests.java
@@ -18,6 +18,7 @@ import uk.ac.ox.ndph.mts.security.exception.RestException;
 import uk.ac.ox.ndph.mts.siteserviceclient.SiteServiceClient;
 import uk.ac.ox.ndph.mts.siteserviceclient.model.SiteDTO;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -332,7 +333,7 @@ class AuthorisationServiceTests {
         when(practitionerServiceClient.getUserRoleAssignments(userId, token)).thenReturn(roleAssignments);
 
         //Act
-        var authResponse = authorisationService.filterUserSites(sitesToFilter);
+        var authResponse = authorisationService.filterUserSites(sitesToFilter, null);
 
         //Assert
         assertAll(
@@ -365,7 +366,7 @@ class AuthorisationServiceTests {
         when(practitionerServiceClient.getUserRoleAssignments(userId, token)).thenReturn(roleAssignments);
 
         //Act
-        var authResponse = authorisationService.filterUserSites(sitesToFilter);
+        var authResponse = authorisationService.filterUserSites(sitesToFilter, null);
 
         //Assert
         assertAll(
@@ -373,6 +374,46 @@ class AuthorisationServiceTests {
                 () -> assertEquals(2, sitesToFilter.size()),
                 () -> assertTrue(sitesToFilter.contains(childSite1)),
                 () -> assertTrue(sitesToFilter.contains(grandChildSite))
+        );
+
+    }
+
+    @Test
+    void TestFilterMySites_ForAdminUserWithRoleAssignment_ReturnsFilteredSitesOnly(){
+        //Arrange
+        var parentSite = new SiteDTO("cco", null);
+        var childSite1 = new SiteDTO("regiona", parentSite.getSiteId());
+        var grandChildSite1 = new SiteDTO("hospital", childSite1.getSiteId());
+        var greatGrandChildSite1 = new SiteDTO("ward", grandChildSite1.getSiteId());
+        var childSite2 = new SiteDTO("regionb", parentSite.getSiteId());
+
+        List<SiteDTO> sitesToFilter = Lists.list(parentSite, childSite1, grandChildSite1, greatGrandChildSite1, childSite2);
+
+        RoleAssignmentDTO suRoleAssignment1 = getRoleAssignment("superuser", parentSite.getSiteId());
+        RoleAssignmentDTO adminRoleAssignment1 = getRoleAssignment("admin", childSite1.getSiteId());
+        RoleAssignmentDTO adminRoleAssignment2 = getRoleAssignment("admin", grandChildSite1.getSiteId());
+        RoleAssignmentDTO adminRoleAssignment3 = getRoleAssignment("admin", greatGrandChildSite1.getSiteId());
+
+        RoleAssignmentDTO[] roleAssignments= {suRoleAssignment1, adminRoleAssignment1, adminRoleAssignment2, adminRoleAssignment3};
+
+        String userId = "123";
+        String token = "token";
+        when(securityContextUtil.getUserId()).thenReturn(userId);
+        when(securityContextUtil.getToken()).thenReturn(token);
+
+        when(practitionerServiceClient.getUserRoleAssignments(userId, token)).thenReturn(Arrays.asList(roleAssignments));
+
+        //Act
+        var authResponse = authorisationService.filterUserSites(sitesToFilter, "admin");
+
+        //Assert
+        assertAll(
+            () -> assertTrue(authResponse),
+            () -> assertEquals(3, sitesToFilter.size()),
+            () -> assertTrue(sitesToFilter.contains(childSite1)),
+            () -> assertTrue(sitesToFilter.contains(grandChildSite1)),
+            () -> assertTrue(sitesToFilter.contains(greatGrandChildSite1)),
+            () -> assertFalse(sitesToFilter.contains(parentSite))
         );
 
     }
@@ -395,7 +436,7 @@ class AuthorisationServiceTests {
         when(practitionerServiceClient.getUserRoleAssignments(userId, token)).thenReturn(Lists.emptyList());
 
         //Act
-        var authResponse = authorisationService.filterUserSites(sitesToFilter);
+        var authResponse = authorisationService.filterUserSites(sitesToFilter, null);
 
         //Assert
         assertFalse(authResponse);
@@ -439,12 +480,19 @@ class AuthorisationServiceTests {
     }
 
     private List<RoleAssignmentDTO> getRoleAssignments(String roleId, String siteId){
+        List<RoleAssignmentDTO> roleAssignmentDTOS = new ArrayList<RoleAssignmentDTO>();
+        roleAssignmentDTOS.add(getRoleAssignment(roleId, siteId));
+
+        return roleAssignmentDTOS;
+
+    }
+
+    private RoleAssignmentDTO getRoleAssignment(String roleId, String siteId){
         RoleAssignmentDTO roleAssignmentDTO = new RoleAssignmentDTO();
         roleAssignmentDTO.setRoleId(roleId);
         roleAssignmentDTO.setSiteId(siteId);
 
-        return Collections.singletonList(roleAssignmentDTO);
-
+        return roleAssignmentDTO;
     }
 
     private static class TestEntityObject{

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/controller/SiteController.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/controller/SiteController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ox.ndph.mts.site_service.model.Response;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
@@ -36,9 +37,9 @@ public class SiteController {
         return ResponseEntity.status(HttpStatus.CREATED).body(new Response(siteId));
     }
 
-    @PostAuthorize("@authorisationService.filterUserSites(returnObject.getBody())")
+    @PostAuthorize("@authorisationService.filterUserSites(returnObject.getBody(), #role)")
     @GetMapping
-    public ResponseEntity<List<Site>> sites() {
+    public ResponseEntity<List<Site>> sites(@RequestParam(value = "role", required = false) String role) {
         return ResponseEntity.status(HttpStatus.OK).body(siteService.findSites());
     }
 

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverter.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverter.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Component;
 import uk.ac.ox.ndph.mts.site_service.model.SiteAddress;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
 /**
  * Implement an EntityConverter for Site. Reverse of {@link OrganizationConverter}.
  */
@@ -27,8 +30,8 @@ public class SiteConverter implements EntityConverter<org.hl7.fhir.r4.model.Orga
                 org.getName(),
                 (org.getAlias().isEmpty()) ? null : org.getAlias().get(0).getValueAsString(),
                 findParentSiteId(org),
-                org.getImplicitRules()
-        );
+                org.getImplicitRules(),
+                LocalDateTime.ofInstant(org.getMeta().getLastUpdated().toInstant(), ZoneId.systemDefault()));
         site.setAddress(findAddress(org));
         return site;
     }

--- a/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/Site.java
+++ b/site-service/src/main/java/uk/ac/ox/ndph/mts/site_service/model/Site.java
@@ -1,5 +1,7 @@
 package uk.ac.ox.ndph.mts.site_service.model;
 
+import java.time.LocalDateTime;
+
 /**
  * Site Model
  */
@@ -66,12 +68,30 @@ public class Site {
         this(name, alias, parentSiteId, siteType);
         this.siteId = siteId;
     }
+
+    /**
+     * Site Constructor with siteId name alias parent siteType
+     * @param siteId site ID
+     * @param name the Site name
+     * @param alias the Site alias
+     * @param parentSiteId the Site parentSiteId
+     * @param siteType the Site siteType
+     * @param lastUpdated lastUpdated timestamp
+     *
+     */
+    public Site(final String siteId, String name, String alias, String parentSiteId,
+                String siteType, LocalDateTime lastUpdated) {
+        this(name, alias, parentSiteId, siteType);
+        this.siteId = siteId;
+        this.lastUpdated = lastUpdated;
+    }
     private String name;
     private String alias;
     private String siteId;
     private String parentSiteId;
     private String siteType;
     private SiteAddress address;
+    private LocalDateTime lastUpdated;
 
     /**
      * Returns the name associated with the Site.
@@ -168,5 +188,13 @@ public class Site {
 
     public void setAddress(SiteAddress siteAddress) {
         this.address = siteAddress;
+    }
+
+    public LocalDateTime getLastUpdated() {
+        return lastUpdated;
+    }
+
+    public void setLastUpdated(LocalDateTime lastUpdated) {
+        this.lastUpdated = lastUpdated;
     }
 }

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/SiteServiceImplIntegrationTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/SiteServiceImplIntegrationTests.java
@@ -16,6 +16,7 @@ import uk.ac.ox.ndph.mts.site_service.exception.RestException;
 import uk.ac.ox.ndph.mts.site_service.repository.FhirRepository;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -51,9 +52,11 @@ class SiteServiceImplIntegrationTests {
         final String rootSiteId = "root-site-id";
         final String parentSiteType = "CCO";
         final String siteType = "REGION";
+        final Date lastUpdated = new Date(System.currentTimeMillis());
         final Organization root = new Organization();
         root.setId(rootSiteId);
         root.setImplicitRules(parentSiteType);
+        root.getMeta().setLastUpdated(new Date(System.currentTimeMillis()));
         when(repository.findOrganizationById(rootSiteId)).thenReturn(Optional.of(root));
         when(repository.saveOrganization(any(Organization.class))).thenReturn("123");
         when(repository.saveResearchStudy(any(ResearchStudy.class))).thenReturn("789");
@@ -86,6 +89,7 @@ class SiteServiceImplIntegrationTests {
         final Organization root = new Organization();
         root.setId(rootSiteId);
         root.setImplicitRules(parentSiteType);
+        root.getMeta().setLastUpdated(new Date(System.currentTimeMillis()));
         when(repository.findOrganizationById(anyString())).thenReturn(Optional.of(root));
         when(repository.saveOrganization(any(Organization.class))).thenThrow(new RestException("test error"));
         String jsonString = "{\"name\": \"name\", \"alias\": \"alias\", \"parentSiteId\": \"parentSiteId\", \"siteType\": \"REGION\"}";
@@ -103,6 +107,7 @@ class SiteServiceImplIntegrationTests {
         final Organization root = new Organization();
         root.setId("parentSiteId");
         root.setImplicitRules("CCO");
+        root.getMeta().setLastUpdated(new Date(System.currentTimeMillis()));
         when(repository.findOrganizationById(("parentSiteId"))).thenReturn(Optional.of(root));
         when(repository.saveOrganization(any(Organization.class))).thenReturn("123");
         when(repository.saveResearchStudy(any(ResearchStudy.class))).thenReturn("789");
@@ -121,6 +126,7 @@ class SiteServiceImplIntegrationTests {
                 .setName("CCO")
                 .addAlias("Root");
         org.setId("this-is-my-id");
+        org.getMeta().setLastUpdated(new Date(System.currentTimeMillis()));
         when(repository.findOrganizations()).thenReturn(List.of(org));
         // Act + Assert
         this.mockMvc
@@ -149,6 +155,7 @@ class SiteServiceImplIntegrationTests {
                 .setName("CCO")
                 .addAlias("Root");
         org.setId(id);
+        org.getMeta().setLastUpdated(new Date(System.currentTimeMillis()));
         when(repository.findOrganizationById(org.getId())).thenReturn(Optional.of(org));
         // Act + Assert
         final var content = this.mockMvc

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/TestAuthorisationConfigurationProvider.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/TestAuthorisationConfigurationProvider.java
@@ -20,7 +20,7 @@ public class TestAuthorisationConfigurationProvider {
         Mockito.when(mockService.authorise(anyString())).thenReturn(true);
         Mockito.when(mockService.authorise(anyString(), anyString())).thenReturn(true);
         Mockito.when(mockService.authorise(anyString(), anyList())).thenReturn(true);
-        Mockito.when(mockService.filterUserSites(anyList())).thenReturn(true);
+        Mockito.when(mockService.filterUserSites(anyList(), any())).thenReturn(true);
         return mockService;
     }
 }

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverterTest.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/converter/SiteConverterTest.java
@@ -5,6 +5,10 @@ import org.hl7.fhir.r4.model.Reference;
 import org.junit.jupiter.api.Test;
 import uk.ac.ox.ndph.mts.site_service.model.Site;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -39,6 +43,7 @@ class SiteConverterTest {
         org.setId(SERVER_ORG_ID);
         org.addAlias(ORG_ALIAS);
         org.setPartOf(new Reference(SERVER_PARENT_ID));
+        org.getMeta().setLastUpdated(new Date(System.currentTimeMillis()));
         // act
         final Site site = siteConverter.convert(org);
         // assert
@@ -46,6 +51,8 @@ class SiteConverterTest {
         assertThat(SERVER_ORG_ID, containsString(site.getSiteId()));
         assertThat(site.getAlias(), is(equalTo(ORG_ALIAS)));
         assertThat(SERVER_PARENT_ID, containsString(site.getParentSiteId()));
+        assertThat(site.getLastUpdated(),
+            equalTo(LocalDateTime.ofInstant(org.getMeta().getLastUpdated().toInstant(), ZoneId.systemDefault())));
     }
 
     @Test
@@ -56,6 +63,7 @@ class SiteConverterTest {
         org.setId(SERVER_ORG_ID);
         org.addAlias(ORG_ALIAS);
         org.setPartOf(new Reference(SERVER_PARENT_ID));
+        org.getMeta().setLastUpdated(new Date(System.currentTimeMillis()));
         org.addAddress().addLine(ADDRESS_1).addLine(ADDRESS_2).
                 addLine(ADDRESS_3).addLine(ADDRESS_4).addLine(ADDRESS_5).
                 setCity(CITY).setCountry(COUNTRY).setPostalCode(POSTCODE);
@@ -67,6 +75,8 @@ class SiteConverterTest {
         assertThat(SERVER_ORG_ID, containsString(site.getSiteId()));
         assertThat(site.getAlias(), is(equalTo(ORG_ALIAS)));
         assertThat(SERVER_PARENT_ID, containsString(site.getParentSiteId()));
+        assertThat(site.getLastUpdated(),
+            equalTo(LocalDateTime.ofInstant(org.getMeta().getLastUpdated().toInstant(), ZoneId.systemDefault())));
         assertThat(site.getAddress().getAddress1(), is(equalTo(ADDRESS_1)));
         assertThat(site.getAddress().getAddress2(), is(equalTo(ADDRESS_2)));
         assertThat(site.getAddress().getAddress3(), is(equalTo(ADDRESS_3)));
@@ -85,6 +95,7 @@ class SiteConverterTest {
         org.setId(SERVER_ORG_ID);
         org.addAlias(ORG_ALIAS);
         org.setPartOf(new Reference(SERVER_PARENT_ID));
+        org.getMeta().setLastUpdated(new Date(System.currentTimeMillis()));
         org.addAddress().addLine(ADDRESS_1).
                 setCity(CITY).setCountry(COUNTRY).setPostalCode(POSTCODE);
         siteConverter.setConverter(siteAddressConverter);
@@ -96,6 +107,8 @@ class SiteConverterTest {
         assertThat(site.getAlias(), is(equalTo(ORG_ALIAS)));
         assertThat(SERVER_PARENT_ID, containsString(site.getParentSiteId()));
         assertThat(site.getAddress().getAddress1(), is(equalTo(ADDRESS_1)));
+        assertThat(site.getLastUpdated(),
+            equalTo(LocalDateTime.ofInstant(org.getMeta().getLastUpdated().toInstant(), ZoneId.systemDefault())));
         assertThat(site.getAddress().getCity(), is(equalTo(CITY)));
         assertThat(site.getAddress().getCountry(), is(equalTo(COUNTRY)));
         assertThat(site.getAddress().getPostcode(), is(equalTo(POSTCODE)));
@@ -108,6 +121,7 @@ class SiteConverterTest {
         org.setId(SERVER_ORG_ID);
         org.addAlias(ORG_ALIAS);
         org.setPartOf(new Reference(SERVER_PARENT_ID));
+        org.getMeta().setLastUpdated(new Date(System.currentTimeMillis()));
         org.addAddress().setId("1");
         siteConverter.setConverter(siteAddressConverter);
         // act
@@ -125,6 +139,8 @@ class SiteConverterTest {
         assertThat(site.getAddress().getCity(), is(equalTo("")));
         assertThat(site.getAddress().getCountry(), is(equalTo("")));
         assertThat(site.getAddress().getPostcode(), is(equalTo("")));
+        assertThat(site.getLastUpdated(),
+            equalTo(LocalDateTime.ofInstant(org.getMeta().getLastUpdated().toInstant(), ZoneId.systemDefault())));
     }
 
     @Test
@@ -134,6 +150,7 @@ class SiteConverterTest {
         org.setName(ORG_NAME);
         org.setId(SERVER_ORG_ID);
         org.addAlias(ORG_ALIAS);
+        org.getMeta().setLastUpdated(new Date(System.currentTimeMillis()));
         // act
         final Site site = siteConverter.convert(org);
         // assert
@@ -141,6 +158,8 @@ class SiteConverterTest {
         assertThat(SERVER_ORG_ID, containsString(site.getSiteId()));
         assertThat(site.getAlias(), is(equalTo(ORG_ALIAS)));
         assertThat(site.getParentSiteId(), is(nullValue()));
+        assertThat(site.getLastUpdated(),
+            equalTo(LocalDateTime.ofInstant(org.getMeta().getLastUpdated().toInstant(), ZoneId.systemDefault())));
     }
 
     @Test
@@ -149,6 +168,7 @@ class SiteConverterTest {
         final Organization org = new Organization();
         org.setName(ORG_NAME);
         org.setId(SERVER_ORG_ID);
+        org.getMeta().setLastUpdated(new Date(System.currentTimeMillis()));
         org.setPartOf(new Reference(SERVER_PARENT_ID));
         // act
         final Site site = siteConverter.convert(org);
@@ -157,6 +177,8 @@ class SiteConverterTest {
         assertThat(SERVER_ORG_ID, containsString(site.getSiteId()));
         assertThat(site.getAlias(), is(nullValue()));
         assertThat(SERVER_PARENT_ID, containsString(site.getParentSiteId()));
+        assertThat(site.getLastUpdated(),
+            equalTo(LocalDateTime.ofInstant(org.getMeta().getLastUpdated().toInstant(), ZoneId.systemDefault())));
     }
 
     @Test
@@ -167,6 +189,7 @@ class SiteConverterTest {
         org.setId(SERVER_ORG_ID);
         org.setPartOf(new Reference(SERVER_PARENT_ID));
         org.addAlias(null);
+        org.getMeta().setLastUpdated(new Date(System.currentTimeMillis()));
         // act
         final Site site = siteConverter.convert(org);
         // assert
@@ -174,6 +197,8 @@ class SiteConverterTest {
         assertThat(SERVER_ORG_ID, containsString(site.getSiteId()));
         assertThat(site.getAlias(), is(nullValue()));
         assertThat(SERVER_PARENT_ID, containsString(site.getParentSiteId()));
+        assertThat(site.getLastUpdated(),
+            equalTo(LocalDateTime.ofInstant(org.getMeta().getLastUpdated().toInstant(), ZoneId.systemDefault())));
     }
 
 }

--- a/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/repository/SiteStoreTests.java
+++ b/site-service/src/test/java/uk/ac/ox/ndph/mts/site_service/repository/SiteStoreTests.java
@@ -8,7 +8,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.ac.ox.ndph.mts.site_service.converter.OrganizationConverter;
 import uk.ac.ox.ndph.mts.site_service.converter.SiteConverter;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
+import java.util.Date;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -35,11 +38,14 @@ class SiteStoreTests {
         // arrange
         final var org = new Organization();
         org.setName("Root");
+        org.getMeta().setLastUpdated(new Date(System.currentTimeMillis()));
         when(fhirRepo.findOrganizationsByPartOf(isNull())).thenReturn(Collections.singletonList(org));
         final var store = new SiteStore(fhirRepo, new OrganizationConverter(), new SiteConverter());
         // act + assert
         assertThat(store.findRoot().isPresent(), equalTo(true));
         assertThat(store.findRoot().get().getName(), equalTo(org.getName()));
+        assertThat(store.findRoot().get().getLastUpdated(),
+            equalTo(LocalDateTime.ofInstant(org.getMeta().getLastUpdated().toInstant(), ZoneId.systemDefault())));
     }
 
 }


### PR DESCRIPTION
## Description
Adding a filter on the get site endpoint. A role parameter can be passed in to filter the sites by the role type i.e admin. 

### Changes
- [ARTS-774] - allow sites to be filtered by role type
- also added role/site/practitioner config to init-service local config as per the deployed init-service config.
### Checklist:

- [ ] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR


[ARTS-774]: https://ndph-arts.atlassian.net/browse/ARTS-774