### PR TITLE
[ARTS 916] fix config for local discovery server 

### DIFF
--- a/config-server/src/main/resources/bootstrap-local.yml
+++ b/config-server/src/main/resources/bootstrap-local.yml
@@ -4,4 +4,4 @@ spring:
     config:
       enabled: false
     discovery:
-      enabled: false
+      enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,9 +51,12 @@ services:
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
       LOGGING_LEVEL_ROOT: ${LOGGING_LEVEL_ROOT:-INFO}
+      ROLE_SERVICE_URI: "http://role-service:8082"
     depends_on:
-      - config-server
-      - sql
+        config-server:
+          condition: service_healthy
+        sql:
+          condition: service_healthy
     healthcheck:
       test: curl --fail http://localhost:8082/actuator/health
       interval: 10s
@@ -79,6 +82,7 @@ services:
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
       LOGGING_LEVEL_ROOT: ${LOGGING_LEVEL_ROOT:-INFO}
+      ROLE_SERVICE_URI: "http://role-service:8082"
     healthcheck:
       test: curl --fail http://localhost:8083/actuator/health
       interval: 10s
@@ -219,6 +223,6 @@ services:
       test: [ "CMD", "/opt/mssql-tools/bin/sqlcmd","-U sa -P ${SAPASSWORD} -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" ]
       interval: 10s
       timeout: 10s
-      retries: 6
+      retries: 10
     ports:
       - "1433:1433"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,10 +53,8 @@ services:
       LOGGING_LEVEL_ROOT: ${LOGGING_LEVEL_ROOT:-INFO}
       ROLE_SERVICE_URI: "http://role-service:8082"
     depends_on:
-        config-server:
-          condition: service_healthy
-        sql:
-          condition: service_healthy
+      - config-server
+      - sql
     healthcheck:
       test: curl --fail http://localhost:8082/actuator/health
       interval: 10s
@@ -115,7 +113,7 @@ services:
       AZURE_CLIENT_ID: ${INIT_AZURE_CLIENT_ID}
       AZURE_CLIENT_SECRET: ${INIT_AZURE_CLIENT_SECRET}
       AZURE_TENANT_ID: ${INIT_AZURE_TENANT_ID}
-      LOGGING_LEVEL_ROOT: DEBUG # always debug
+      LOGGING_LEVEL_ROOT: : # always debug
     depends_on:
       - practitioner-service
       - role-service
@@ -223,6 +221,6 @@ services:
       test: [ "CMD", "/opt/mssql-tools/bin/sqlcmd","-U sa -P ${SAPASSWORD} -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" ]
       interval: 10s
       timeout: 10s
-      retries: 10
+      retries: 6
     ports:
       - "1433:1433"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
       AZURE_CLIENT_ID: ${INIT_AZURE_CLIENT_ID}
       AZURE_CLIENT_SECRET: ${INIT_AZURE_CLIENT_SECRET}
       AZURE_TENANT_ID: ${INIT_AZURE_TENANT_ID}
-      LOGGING_LEVEL_ROOT: : # always debug
+      LOGGING_LEVEL_ROOT: DEBUG # always debug
     depends_on:
       - practitioner-service
       - role-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
       LOGGING_LEVEL_ROOT: ${LOGGING_LEVEL_ROOT:-INFO}
-      ROLE_SERVICE_URI: "http://role-service:8082"
+      AZURE_ACTIVEDIRECTORY_CLIENT-ID: ${MTS_AZURE_APP_CLIENT_ID}
     depends_on:
       - config-server
       - sql
@@ -80,7 +80,7 @@ services:
       SPRING_CLOUD_CONFIG_LABEL: "main"
       SPRING_CLOUD_CONFIG_URI: "http://config-server:8888"
       LOGGING_LEVEL_ROOT: ${LOGGING_LEVEL_ROOT:-INFO}
-      ROLE_SERVICE_URI: "http://role-service:8082"
+      AZURE_ACTIVEDIRECTORY_CLIENT-ID: ${MTS_AZURE_APP_CLIENT_ID}
     healthcheck:
       test: curl --fail http://localhost:8083/actuator/health
       interval: 10s

--- a/init-service/src/main/resources/bootstrap-local.yml
+++ b/init-service/src/main/resources/bootstrap-local.yml
@@ -5,7 +5,7 @@ spring:
       discovery:
         enabled: false
     discovery:
-      enabled: false
+      enabled: true
 # Ribbon is a client-side load balancer, this property disables the use of Eureka in Ribbon
 ribbon:
   eureka:

--- a/practitioner-service/src/main/resources/bootstrap-local.yml
+++ b/practitioner-service/src/main/resources/bootstrap-local.yml
@@ -5,7 +5,7 @@ spring:
       discovery:
         enabled: false
     discovery:
-      enabled: false
+      enabled: true
 # Ribbon is a client-side load balancer, this property disables the use of Eureka in Ribbon
 ribbon:
   eureka:

--- a/role-service/src/main/resources/bootstrap-local.yml
+++ b/role-service/src/main/resources/bootstrap-local.yml
@@ -5,5 +5,5 @@ spring:
       discovery:
         enabled: false
     discovery:
-      enabled: false
+      enabled: true
 

--- a/security/src/main/resources/application.yml
+++ b/security/src/main/resources/application.yml
@@ -31,3 +31,11 @@ site-service:
 
 init-service:
   identity: <init-service-identity>
+
+
+role:
+  service:
+    name: role-service
+    uri: http://role-service
+    endpoint:
+      sites: /roles

--- a/site-service/src/main/resources/bootstrap-local.yml
+++ b/site-service/src/main/resources/bootstrap-local.yml
@@ -5,4 +5,4 @@ spring:
       discovery:
         enabled: false
     discovery:
-      enabled: false
+      enabled: true


### PR DESCRIPTION
## Description
Init-service waits for other services to appear in the discovery-server registry (See https://github.com/NDPH-ARTS/mts-services/blob/main/init-service/src/main/java/uk/ac/ox/ndph/mts/init_service/loader/Loader.java).   At the moment all services have discovery switched off in local profile.   So if we we want the option to run init-service locally, we need to run discovery locally, or do a workaround.

### Changes
- [ARTS-916] 

### Checklist:

- [x] Branch name follows convention (feature/arts-#-short-name OR fix/arts-#-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-196]: https://ndph-arts.atlassian.net/browse/ARTS-196

[ARTS-916]: https://ndph-arts.atlassian.net/browse/ARTS-916